### PR TITLE
Split command line arguments & config file parameter & add ZMQ-ENABLED

### DIFF
--- a/getting-started/0.1/tutorials/run-your-own-iri-node.md
+++ b/getting-started/0.1/tutorials/run-your-own-iri-node.md
@@ -24,7 +24,7 @@ To complete this tutorial, you need the following:
 * Access to a terminal
 * An Internet connection
 
-<hr>
+---
 
 1. [Install Docker](https://docs.docker.com/install/#supported-platforms). If you're running a version of Mac or Windows that's older than the system requirements, install the [Docker toolbox](https://docs.docker.com/toolbox/overview/) instead.
 

--- a/getting-started/0.1/tutorials/send-a-zero-value-transaction-with-nodejs.md
+++ b/getting-started/0.1/tutorials/send-a-zero-value-transaction-with-nodejs.md
@@ -11,7 +11,7 @@ To complete this tutorial, you need the following:
 * Access to a terminal
 * An Internet connection
 
-<hr>
+---
 
 In IOTA, transactions must be sent to [IRI nodes](root://iri/0.1/introduction/overview.md).
 
@@ -205,7 +205,7 @@ The value of the `seed` constant is the seed that is used to generate an address
 
 **Note:** Seeds and address must both contain 81 tryte-encoded characters. If a seed consists of less than 81 characters, the library will append 9s to the end of it to make 81 characters. 
 
-<hr>
+---
 
 ```javascript
 const transfers = [
@@ -219,7 +219,7 @@ const transfers = [
 The `transfers` array lets you specify transfers you want to make from
 an address. In this case, you send a transfer with no value to an address and you include the tryte-encoded message 'Hello World!'.
 
-<hr>
+---
 
 ```javascript
     iota.prepareTransfers(seed, transfers)

--- a/getting-started/0.1/tutorials/send-a-zero-value-transaction-with-the-trinity-wallet.md
+++ b/getting-started/0.1/tutorials/send-a-zero-value-transaction-with-the-trinity-wallet.md
@@ -9,7 +9,7 @@ Trinity allows you to do the following:
 
 <img src="../trinity-home.jpg" alt="Trinity" width="600">
 
-<hr>
+---
 
 1. [Download and install Trinity](https://trinity.iota.org/)
 2. Open Trinity

--- a/hub/0.1/concepts/cryptocurrency-exchange-implementations.md
+++ b/hub/0.1/concepts/cryptocurrency-exchange-implementations.md
@@ -7,7 +7,7 @@ In this guide, we discuss two possible scenarios:
 - **Scenario A:** Multiple user accounts for generating deposit addresses, but funds are manually moved out of these upon deposit into a central hot or Hub account.
 - **Scenario B:** Multiple user accounts with individual balances.
 
-<hr>
+---
 
 ## Scenario A
 

--- a/iota-basics/0.1/how-to-guides/convert-data-to-trytes.md
+++ b/iota-basics/0.1/how-to-guides/convert-data-to-trytes.md
@@ -6,7 +6,7 @@
 
 To complete this guide, your computer must have [Node JS (8+)](https://nodejs.org/en/) installed.
 
-<hr>
+---
 
 1. Create a new directory called iota-basics
 2. In the command line, change into the iota-basics directory, and install the [IOTA Converter library](https://github.com/iotaledger/iota.js/tree/next/packages/converter)

--- a/iota-basics/0.1/how-to-guides/generate-an-address.md
+++ b/iota-basics/0.1/how-to-guides/generate-an-address.md
@@ -8,7 +8,7 @@ Any code that uses a seed is executed on the client side. Your seed is never sen
 
 To complete this guide, your computer must have [Node JS (8+)](https://nodejs.org/en/) installed.
 
-<hr>
+---
 
 1. Create a new directory called iota-basics
 2. In the command line, change into the iota-basics directory, and install the [IOTA Core library](https://github.com/iotaledger/iota.js/tree/next/packages/core)

--- a/iota-basics/0.1/how-to-guides/send-bundle.md
+++ b/iota-basics/0.1/how-to-guides/send-bundle.md
@@ -8,7 +8,7 @@ Any code that uses a seed is executed on the client side. Your seed is never sen
 
 To complete this guide, your computer must have [Node JS (8+)](https://nodejs.org/en/) installed.
 
-<hr>
+---
 
 1. Create a new directory called iota-basics
 2. In the command line, change into the iota-basics directory, and install the [IOTA Core library](https://github.com/iotaledger/iota.js/tree/next/packages/core)

--- a/iri/0.1/how-to-guides/prune-transactions-from-the-ledger.md
+++ b/iri/0.1/how-to-guides/prune-transactions-from-the-ledger.md
@@ -13,7 +13,7 @@ current milestone index - ([`LOCAL_SNAPSHOTS_DEPTH`](../references/iri-configura
 
 You must stop the IRI before making changes to the configuration options.
 
-<hr>
+---
 
 1. Make sure that the `LOCAL_SNAPSHOTS_ENABLED` and the `LOCAL_SNAPSHOTS_PRUNING_ENABLED` configuration options are set to `true`
 2. Change the value of the `LOCAL_SNAPSHOTS_PRUNING_DELAY` and the `LOCAL_SNAPSHOTS_DEPTH` configuration options

--- a/iri/0.1/how-to-guides/run-an-iri-node-in-docker.md
+++ b/iri/0.1/how-to-guides/run-an-iri-node-in-docker.md
@@ -15,7 +15,7 @@
     * **TCP neighbor peering port:** 14600
     * **TCP API port:** 14265
 
-<hr>
+---
 
 The IRI Docker container is suitable for the following operating systems:
 * Linux

--- a/iri/0.1/how-to-guides/run-an-iri-node-on-linux.md
+++ b/iri/0.1/how-to-guides/run-an-iri-node-on-linux.md
@@ -15,7 +15,7 @@
     * **TCP neighbor peering port:** 14600
     * **TCP API port:** 14265
 
-<hr>
+---
 
 The IRI is Java software, so it must be run in a Java runtime environment (JRE).
 

--- a/iri/0.1/references/iri-configuration-options.md
+++ b/iri/0.1/references/iri-configuration-options.md
@@ -48,7 +48,7 @@ You can choose to configure the IRI by specifying the configuration options in t
 |<a name="udp-receiver-port"></a>`-u`, `--udp-receiver-port` |Port from which the IRI receives UDP data packets from neighbor IRI nodes |string |14600 |
 |<a name="zmq-enabled"></a>  `--zmq-enabled` | Enable [zero message queue](../concepts/zero-message-queue.md) subscriptions| boolean|false |
 |<a name="zmq-ipc"></a>`--zmq-ipc` |Path that is used to communicate with ZMQ in IPC| string|  ipc://iri|
-|<a name="zmq-port"></a> `--zmq-port `|Port that is used to connect to the ZMQ feed |string | 5556|
+|<a name="zmq-port"></a> `--zmq-port `|Port that is used to connect to the ZMQ feed |string | 5556| |
 
 ### IRI Configuration file
 | **Configuration options** |   **Description**| **Accepted values** | **Default values**|**Notes** |
@@ -59,4 +59,6 @@ You can choose to configure the IRI by specifying the configuration options in t
 |<a name="local-snapshots-pruning-delay"></a>`LOCAL_SNAPSHOTS_PRUNING_DELAY`  | Amount of milestone transactions to keep in the ledger   | number starting from 10,000  | 40,000 | We recommend that you use the default value for this option, which triggers a local snapshot around every 28 days.  |
 |<a name="local-snapshots-interval-synced"></a>`LOCAL_SNAPSHOTS_INTERVAL_SYNCED`  | Interval, in milestone transactions, at which snapshot files are created if the ledger is fully synchronized  |number| 10   | |
 |<a name="local-snapshots-interval-unsynced"></a>`LOCAL_SNAPSHOTS_INTERVAL_UNSYNCED`   | Interval, in milestone transactions, at which snapshot files are created if the ledger is not fully synchronized  |number| 1,000  | This value is higher than the `LOCAL_SNAPSHOTS_INTERVAL_SYNCED` configuration option to allow the IRI to focus its resources on synchronizing with its neighbor IRI nodes|
-|<a name="local-snapshots-base-path"></a>`LOCAL_SNAPSHOTS_BASE_PATH`  |  Path to the snapshot file, without the file extension. |  string |  mainnet   | Prepends the `.snapshot.meta` and `.snapshot.state` files with the value of this parameter. For the default value, the files are named `mainnet.snapshot.meta` and `mainnet.snapshot.state`. You can specify a directory for the files to be added to by doing the following: `<directory name>/<file name>`, which results in `folderpath/filename.snapshot.meta`. | |
+|<a name="local-snapshots-base-path"></a>`LOCAL_SNAPSHOTS_BASE_PATH`  |  Path to the snapshot file, without the file extension. |  string |  mainnet   | Prepends the `.snapshot.meta` and `.snapshot.state` files with the value of this parameter. For the default value, the files are named `mainnet.snapshot.meta` and `mainnet.snapshot.state`. You can specify a directory for the files to be added to by doing the following: `<directory name>/<file name>`, which results in `folderpath/filename.snapshot.meta`. |
+|<a name="local-snapshots-base-path"></a>`ZMQ-ENABLED`  |  Enable [zero message queue](../concepts/zero-message-queue.md) subscriptions |  boolean |  false   |  |
+

--- a/iri/0.1/references/iri-configuration-options.md
+++ b/iri/0.1/references/iri-configuration-options.md
@@ -6,6 +6,8 @@ You can choose to configure the IRI by specifying the configuration options in t
 * As flags in the command line
 * As parameters in a file with the .ini extension (IRI configuration file)
 
+### Command line flags
+
 | **Configuration options** |   **Description**| **Accepted values** | **Default values**|**Notes** |
 | :------------------------ | :--------------- | :--------- | :--------| :------------|
 |<a name="alpha"></a>`--alpha`| Randomness of the tip selection process             |   number between 0 and infinity  |  0.001     | The number 0 is the most random and infinity is the most deterministic|
@@ -47,6 +49,10 @@ You can choose to configure the IRI by specifying the configuration options in t
 |<a name="zmq-enabled"></a>  `--zmq-enabled` | Enable [zero message queue](../concepts/zero-message-queue.md) subscriptions| boolean|false |
 |<a name="zmq-ipc"></a>`--zmq-ipc` |Path that is used to communicate with ZMQ in IPC| string|  ipc://iri|
 |<a name="zmq-port"></a> `--zmq-port `|Port that is used to connect to the ZMQ feed |string | 5556|
+
+### IRI Configuration file
+| **Configuration options** |   **Description**| **Accepted values** | **Default values**|**Notes** |
+| :------------------------ | :--------------- | :--------- | :--------| :------------|
 |<a name="local-snapshots-enabled"></a>`LOCAL_SNAPSHOTS_ENABLED`   | Enable [local snapshots](../concepts/local-snapshot.md) |boolean  | true  | This parameter must be set to `true` for the IRI to read any other `LOCAL_SNAPSHOTS` parameters|
 |<a name="local-snapshots-pruning-enabled"></a>`LOCAL_SNAPSHOTS_PRUNING_ENABLED`  |  Enable the deletion of transactions from the ledger  | true | Transactions are deleted if they were confirmed by a milestone with an index that is older than the result of the following calculation: current milestone index - (`LOCAL_SNAPSHOTS_DEPTH` + `LOCAL_SNAPSHOTS_PRUNING_DELAY`).  |
 |<a name="local-snapshots-depth"></a>`LOCAL_SNAPSHOTS_DEPTH`  | Amount of seen milestones to record in the snapshot.meta file | number starting from 100 | 100 | |

--- a/the-tangle/0.1/concepts/tip-selection.md
+++ b/the-tangle/0.1/concepts/tip-selection.md
@@ -24,7 +24,7 @@ When this endpoint is called the IRI node starts the tip selection algorithm, wh
 2. Rating calculation
 3. Weighted random walk
 
-<hr>
+---
 
 ## Preparation
 


### PR DESCRIPTION
Since https://docs.iota.org/docs/iri/0.1/concepts/zero-message-queue refers to ZMQ-ENABLED, I thought it makes sense to add it. For a better understanding, I split the command line arguments and config file parameter in two different tables. 