### PR TITLE
ZMQ Messages: Correct tx_trytes

### DIFF
--- a/iri/0.1/references/zmq-events.md
+++ b/iri/0.1/references/zmq-events.md
@@ -13,7 +13,7 @@ Index 0 of each array of returned data is not displayed because it is always the
 |  **Event/Description** | **Returned data**
 | :----------| :----------|
 |`mctn`|
-|Number of transactions traversed during tip selection| <ul><li>Index 1: Total number of transactions that were traversed during tip selection</li><li>Index 2: Transaction hash</li></ul></ul>
+|Number of transactions traversed during tip selection| <ul><li>Index 1: Total number of transactions that were traversed during tip selection</li></ul></ul>
 |`dnscv` |
 |Neighbor DNS validations| <ul><li>Index 1: Neighbor's hostname</li><li>Index 2: Neighbor's IP address</li></ul>
 |`dnscc`|
@@ -39,7 +39,7 @@ Index 0 of each array of returned data is not displayed because it is always the
 |`sn`|
 | Transaction in the ledger that the IRI has recently confirmed| <ul><li>Index 1: Transaction hash</li><li>Index 2: Address</li><li>Index 3: Trunk transaction hash</li><li>Index 4: Branch transaction hash</li><li>Index 5: Bundle hash</li></ul>
 |`tx_trytes`|
-| Raw transaction trytes that has recently appended to the ledger| <ul><li>Index 1: [Raw transaction object](root://iota-basics/0.1/references/structure-of-a-transaction)</li></ul>
+| Raw transaction trytes that has recently appended to the ledger| <ul><li>Index 1: [Raw transaction object](root://iota-basics/0.1/references/structure-of-a-transaction)</li><li>Index 2: Transaction hash</li></ul>
 |`tx` |
 |Transactions that the IRI has recently appended to the ledger| **Array 0**<ul><li>Index 1: Transaction hash</li><li>Index 2: Address</li><li>Index 3: Amount of IOTA</li><li>Index 4: Obsolete tag</li><li>Index 5: Timestamp of the bundle creation (seconds since the last snapshot)</li><li>Index 6: Index of the transaction in the bundle</li><li>Index 7: Last transaction index of the bundle</li><li>Index 8: Bundle hash</li><li>Index 9: Trunk transaction hash</li><li>Index 10: Branch transaction hash</li><li>Index 11: Timestamp of the attachment to the Tangle (milliseconds since the last snapshot)</li><li>Index 12: Tag</li></ul>**Array 1**<ul><li>Index 0: "tx_trytes"</li><li>Index 1: Transaction signature</li></ul>
 |81 character address or 90 character address with checksum| 

--- a/iri/0.1/references/zmq-events.md
+++ b/iri/0.1/references/zmq-events.md
@@ -13,7 +13,7 @@ Index 0 of each array of returned data is not displayed because it is always the
 |  **Event/Description** | **Returned data**
 | :----------| :----------|
 |`mctn`|
-|Number of transactions traversed during tip selection| <ul><li>Index 1: Total number of transactions that were traversed during tip selection</li></ul></ul>
+|Number of transactions traversed during tip selection| <ul><li>Index 1: Total number of transactions that were traversed during tip selection</li></ul>
 |`dnscv` |
 |Neighbor DNS validations| <ul><li>Index 1: Neighbor's hostname</li><li>Index 2: Neighbor's IP address</li></ul>
 |`dnscc`|

--- a/iri/0.1/references/zmq-events.md
+++ b/iri/0.1/references/zmq-events.md
@@ -13,7 +13,7 @@ Index 0 of each array of returned data is not displayed because it is always the
 |  **Event/Description** | **Returned data**
 | :----------| :----------|
 |`mctn`|
-|Number of transactions traversed during tip selection| <ul><li>Index 1: Total number of transactions that were traversed during tip selection</li></ul>
+|Number of transactions traversed during tip selection| <ul><li>Index 1: Total number of transactions that were traversed during tip selection</li><li>Index 2: Transaction hash</li></ul></ul>
 |`dnscv` |
 |Neighbor DNS validations| <ul><li>Index 1: Neighbor's hostname</li><li>Index 2: Neighbor's IP address</li></ul>
 |`dnscc`|

--- a/iri/0.1/references/zmq-events.md
+++ b/iri/0.1/references/zmq-events.md
@@ -39,7 +39,7 @@ Index 0 of each array of returned data is not displayed because it is always the
 |`sn`|
 | Transaction in the ledger that the IRI has recently confirmed| <ul><li>Index 1: Transaction hash</li><li>Index 2: Address</li><li>Index 3: Trunk transaction hash</li><li>Index 4: Branch transaction hash</li><li>Index 5: Bundle hash</li></ul>
 |`tx_trytes`|
-| Signature of a transaction that the IRI has recently confirmed| <ul><li>Index 1: Transaction signature</li></ul>
+| Raw transaction trytes that has recently appended to the ledger| <ul><li>Index 1: [Raw transaction object](root://iota-basics/0.1/references/structure-of-a-transaction)</li></ul>
 |`tx` |
 |Transactions that the IRI has recently appended to the ledger| **Array 0**<ul><li>Index 1: Transaction hash</li><li>Index 2: Address</li><li>Index 3: Amount of IOTA</li><li>Index 4: Obsolete tag</li><li>Index 5: Timestamp of the bundle creation (seconds since the last snapshot)</li><li>Index 6: Index of the transaction in the bundle</li><li>Index 7: Last transaction index of the bundle</li><li>Index 8: Bundle hash</li><li>Index 9: Trunk transaction hash</li><li>Index 10: Branch transaction hash</li><li>Index 11: Timestamp of the attachment to the Tangle (milliseconds since the last snapshot)</li><li>Index 12: Tag</li></ul>**Array 1**<ul><li>Index 0: "tx_trytes"</li><li>Index 1: Transaction signature</li></ul>
 |81 character address or 90 character address with checksum| 


### PR DESCRIPTION
I wrote a small parsing library in Scala for Flink. This library throws an error if the message is not in the expected format.

```bash
[info] ERROR PARSING MESSAGE
[info] tx_trytes
[info] List(RCCDBDUCEAQCCDLDEAHDRCCDBDUCEAQCCDLDEAHDLDDBEAYAVAZAZA9999999999999999999999999999999999999999LDDBEAYAVAZAZA99999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999999HIYZWZRQHRWSNZ9UVADZCQZVTJQO9MIFDVDQFWWSECKNVMJAIEXEVGVQGSNUAYNWUZKOWAM9QXJYAQRVX999999999999999999999999999OTNFBOX99999999999999999999AKKUA9D99999999999999999999VIFRGYNHJPSBBGCLPDBVEAFSRTU9QBQLFEDRODOGBZJZBPZSHCEYDUAXXDKVFREOIQDEQYXQFFJRLADAWZ9KWWPZIPLHKEKKTAPXAI9MHBANRYOWP9EROFVSUEGEZRFXTEKJUPTIDRNDVHHHLMAHOBCFJTOZQ99999AAHMI9DFZVYIPYVDBA9WJGIAXY9VZZGAYRWNWPUEINVXTAJOCZYVISJSZPVKJKJBMABWPA9PMLIFZ9999CONFBOX99999999999999999999LQPLJBEME999999999K99999999SZB99999999STA9999999999999, LHW9PIWJINFKNDMHSVCSZLIPPXFFQHKJXFYEHJJBRUWLL9N9ZVIVCSEOMRDTVHZDPIEDDBZRIUWZ99999)
```

Subscribed to the ZMQ stream of tcp://db.iota.partners:5556. Checked the version of the node. The node is up to date.
```bash
citrullin@Thinkpad-X260:~$ curl http://db.iota.partners:14265 \
> -X POST \
> -H 'Content-Type: application/json' \
> -H 'X-IOTA-API-Version: 1' \
> -d '{"command": "getNodeInfo"}' \
> 
{"appName":"IRI","appVersion":"1.6.0-RELEASE","jreAvailableProcessors":4,"jreFreeMemory":1193951032,"jreVersion":"11.0.2","jreMaxMemory":5825888256,"jreTotalMemory":1553989632,"latestMilestone":"WB9DYQOGVVPYMSMFEX9KIFXFGPBWERKEC9BLXPZLRYCLGESHALPVVISJHREZRUYNUHGSQMIWMYGQA9999","latestMilestoneIndex":1007792,"latestSolidSubtangleMilestone":"WB9DYQOGVVPYMSMFEX9KIFXFGPBWERKEC9BLXPZLRYCLGESHALPVVISJHREZRUYNUHGSQMIWMYGQA9999","latestSolidSubtangleMilestoneIndex":1007792,"milestoneStartIndex":997794,"lastSnapshottedMilestoneIndex":1007682,"neighbors":8,"packetsQueueSize":0,"time":1550104477797,"tips":2465,"transactionsToRequest":10,"features":["snapshotPruning","dnsRefresher","zeroMessageQueue","tipSolidification","RemotePOW"],"coordinatorAddress":"KPWCHICGJZXKE9GSUDXZYUAPLHAKAHYHDXNPHENTERYMMBQOPSQIDENXKLKCEYCPVTZQLEEJVYJZV9BWU","duration":1}
```