### PR TITLE
Add flink how to guide to readme and doc-index

### DIFF
--- a/iri/0.1/README.md
+++ b/iri/0.1/README.md
@@ -14,7 +14,7 @@ This section contains information about how IOTA node software works. IOTA node 
     - [Prune transactions from the ledger](/how-to-guides/prune-transactions-from-the-ledger.md)
     - [Interact with an IRI node](how-to-guides/interact-with-an-iri-node.md)
     - [Subscribe to events in an IRI node](how-to-guides/subscribe-to-events-in-an-iri-node.md)
-    - [Professional near real-time transaction stream processing](how-to-guides/flink-tangle-stream-processing.md)
+    - [Process big data transaction stream in near real-time](how-to-guides/flink-tangle-stream-processing.md)
   
 - Concepts
     - [The ledger](concepts/the-ledger.md)

--- a/iri/0.1/README.md
+++ b/iri/0.1/README.md
@@ -14,7 +14,7 @@ This section contains information about how IOTA node software works. IOTA node 
     - [Prune transactions from the ledger](/how-to-guides/prune-transactions-from-the-ledger.md)
     - [Interact with an IRI node](how-to-guides/interact-with-an-iri-node.md)
     - [Subscribe to events in an IRI node](how-to-guides/subscribe-to-events-in-an-iri-node.md)
-    - [Tangle stream processing with Apache Flink](how-to-guides/flink-tangle-stream-processing.md)
+    - [Professional near real-time transaction stream processing](how-to-guides/flink-tangle-stream-processing.md)
   
 - Concepts
     - [The ledger](concepts/the-ledger.md)

--- a/iri/0.1/README.md
+++ b/iri/0.1/README.md
@@ -14,6 +14,7 @@ This section contains information about how IOTA node software works. IOTA node 
     - [Prune transactions from the ledger](/how-to-guides/prune-transactions-from-the-ledger.md)
     - [Interact with an IRI node](how-to-guides/interact-with-an-iri-node.md)
     - [Subscribe to events in an IRI node](how-to-guides/subscribe-to-events-in-an-iri-node.md)
+    - [Tangle stream processing with Apache Flink](how-to-guides/flink-tangle-stream-processing.md)
   
 - Concepts
     - [The ledger](concepts/the-ledger.md)

--- a/iri/0.1/doc-index.md
+++ b/iri/0.1/doc-index.md
@@ -14,6 +14,7 @@
 [How-to Guides/Prune transactions from the ledger](/how-to-guides/prune-transactions-from-the-ledger.md)
 [How-to Guides/Interact with an IRI node](/how-to-guides/interact-with-an-iri-node.md)
 [How-to Guides/Subscribe to events in an IRI node](/how-to-guides/subscribe-to-events-in-an-iri-node.md)
+[How-to Guides/Tangle stream processing with Apache Flink](/how-to-guides/flink-tangle-stream-processing.md)
 [References/Troubleshooting](/references/troubleshooting.md)
 [References/API reference](/references/api-reference.md)
 [References/API errors](/references/api-errors.md)

--- a/iri/0.1/doc-index.md
+++ b/iri/0.1/doc-index.md
@@ -14,7 +14,7 @@
 [How-to Guides/Prune transactions from the ledger](/how-to-guides/prune-transactions-from-the-ledger.md)
 [How-to Guides/Interact with an IRI node](/how-to-guides/interact-with-an-iri-node.md)
 [How-to Guides/Subscribe to events in an IRI node](/how-to-guides/subscribe-to-events-in-an-iri-node.md)
-[How-to Guides/Tangle stream processing with Apache Flink](/how-to-guides/flink-tangle-stream-processing.md)
+[How-to Guides/professional near real-time IOTA transaction stream processing](/how-to-guides/flink-tangle-stream-processing.md)
 [References/Troubleshooting](/references/troubleshooting.md)
 [References/API reference](/references/api-reference.md)
 [References/API errors](/references/api-errors.md)

--- a/iri/0.1/doc-index.md
+++ b/iri/0.1/doc-index.md
@@ -14,7 +14,7 @@
 [How-to Guides/Prune transactions from the ledger](/how-to-guides/prune-transactions-from-the-ledger.md)
 [How-to Guides/Interact with an IRI node](/how-to-guides/interact-with-an-iri-node.md)
 [How-to Guides/Subscribe to events in an IRI node](/how-to-guides/subscribe-to-events-in-an-iri-node.md)
-[How-to Guides/professional near real-time IOTA transaction stream processing](/how-to-guides/flink-tangle-stream-processing.md)
+[How-to Guides/Process big data transaction stream in near real-time](/how-to-guides/flink-tangle-stream-processing.md)
 [References/Troubleshooting](/references/troubleshooting.md)
 [References/API reference](/references/api-reference.md)
 [References/API errors](/references/api-errors.md)

--- a/iri/0.1/how-to-guides/flink-tangle-stream-processing.md
+++ b/iri/0.1/how-to-guides/flink-tangle-stream-processing.md
@@ -1,4 +1,4 @@
-# Near real-time transaction stream processing
+# Near real-time transaction stream processing with Apache Flink
 **Learn how to process IOTA transaction streams in near real-time, 
 while diving into the big data stream processing framework Apache Flink.**
 

--- a/iri/0.1/how-to-guides/flink-tangle-stream-processing.md
+++ b/iri/0.1/how-to-guides/flink-tangle-stream-processing.md
@@ -1,4 +1,6 @@
-# Tangle stream processing with Apache Flink
+# Near real-time transaction stream processing
+**Learn how to process IOTA transaction streams in near real-time, 
+while diving into the big data stream processing framework Apache Flink.**
 
 **_Note:_** The tangle streaming libraries used in this guide are not recommended for production environments.
 Feel free to contribute to the libraries, so that they eventually become production ready.

--- a/iri/0.1/how-to-guides/flink-tangle-stream-processing.md
+++ b/iri/0.1/how-to-guides/flink-tangle-stream-processing.md
@@ -1,4 +1,4 @@
-# Near real-time transaction stream processing with Apache Flink
+# Process big data transaction stream in near real-time with Apache Flink
 **Learn how to process IOTA transaction streams in near real-time, 
 while diving into the big data stream processing framework Apache Flink.**
 


### PR DESCRIPTION
I guess that is the reason why the flink guide is not in the IRI menu, right?