### PR TITLE
Skip fenced object sections during spell check

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ The spell checker uses [Hunspell](https://en.wikipedia.org/wiki/Hunspell
 
 To enhance the spell checker, you can add words to the dictionary.json file, which supports regular expressions. For example:
 
-```
+```json
 {
     "global": [
         "(P|p)ermission(less|ed)"
@@ -46,4 +46,12 @@ To enhance the spell checker, you can add words to the dictionary.json file, whi
         "AstroPi"
     ]
 }
+```
+
+If you want to validate just a single project you can run the script with a command line option of the specific folder name.
+
+e.g.
+
+```shell
+node buildProjects getting-started
 ```

--- a/buildProjects.js
+++ b/buildProjects.js
@@ -454,8 +454,8 @@ function isValidWord(projectFolder, word) {
 
 async function spellCheck(projectFolder, markdown, docPath) {
     if (checkSpelling) {
-        let noCode = markdown.replace(/```([\s\S])*?```/g, '');
-        let noObjects = noCode.replace(/¬¬¬([\s\S])*?¬¬¬/g, '');
+        let noCode = markdown.replace(/```[\s\S]*?```/g, '');
+        let noObjects = noCode.replace(/¬¬¬[\s\S]*?¬¬¬/g, '');
         let noHtml = noObjects.replace(/<(?:.*?)>(.*?)<\/(?:.*?)>/g, ' $1 ');
 
         const html = md({ html: true }).render(noHtml);

--- a/buildProjects.js
+++ b/buildProjects.js
@@ -18,7 +18,7 @@ let dictionary = {};
 let errorCount = 0;
 let warningCount = 0;
 
-async function buildProjects(docsFolder) {
+async function buildProjects(docsFolder, singleProject) {
     try {
         await fsPromises.unlink(reportFile);
     } catch (err) {
@@ -31,7 +31,10 @@ async function buildProjects(docsFolder) {
     await reportEntry(`Reading Project Dir: '${docsFolder}'`);
     await reportEntry('');
 
-    const projects = await readProjects(docsFolder);
+    let projects = await readProjects(docsFolder);
+    if (singleProject) {
+        projects = projects.filter(p => p.folder === singleProject);
+    }
     console.log(`Found ${projects.length} Projects.`);
 
     for (let i = 0; i < projects.length; i++) {
@@ -678,7 +681,7 @@ function loadDictionary() {
     }
 }
 
-async function run() {
+async function run(singleProject) {
     if (checkSpelling && spellingFile) {
         if (fs.existsSync(spellingFile)) {
             fs.unlinkSync(spellingFile);
@@ -686,7 +689,7 @@ async function run() {
         fs.appendFileSync(spellingFile, "# Spelling Summary\n");
         loadDictionary();
     }
-    const projects = await buildProjects(rootFolder);
+    const projects = await buildProjects(rootFolder, singleProject);
 
     if (projectsFile) {
         await fsPromises.writeFile(projectsFile, JSON.stringify(projects, undefined, '\t'));
@@ -712,9 +715,9 @@ async function run() {
 
 console.log(chalk.green.underline.bold('Build Projects'));
 
-const docsFolder = process.argv[2] || 'docs';
+const singleProject = process.argv[2] || '';
 
-run(docsFolder)
+run(singleProject)
     .then(() => console.log(chalk.green(`\n${emoji.get('smile')}  Completed Successfully`)))
     .catch((err) => {
         console.error(chalk.red(`\n${emoji.get('frown')}  Building failed with the following error:`));

--- a/buildProjects.js
+++ b/buildProjects.js
@@ -455,7 +455,8 @@ function isValidWord(projectFolder, word) {
 async function spellCheck(projectFolder, markdown, docPath) {
     if (checkSpelling) {
         let noCode = markdown.replace(/```([\s\S])*?```/g, '');
-        let noHtml = noCode.replace(/<(?:.*?)>(.*?)<\/(?:.*?)>/g, ' $1 ');
+        let noObjects = noCode.replace(/¬¬¬([\s\S])*?¬¬¬/g, '');
+        let noHtml = noObjects.replace(/<(?:.*?)>(.*?)<\/(?:.*?)>/g, ' $1 ');
 
         const html = md({ html: true }).render(noHtml);
         const dom = cheerio.load(html);


### PR DESCRIPTION
Skips object fenced with ¬¬¬ during spell check, they are json objects internally so no point spell checking.

Adds ability to validate just a single folder during buildProjects, so you can validate just the one you are working on.

e.g.

```shell
node buildProjects getting-started
```