### PR TITLE
Update checkConsistency endpoint

### DIFF
--- a/iri/0.1/references/api-reference.md
+++ b/iri/0.1/references/api-reference.md
@@ -469,7 +469,7 @@ curl http://localhost:14265 \
 
 |Return field | Description |
 |--|--|
-| `state` | States of the specified transactions in the same order as the values in the `tails` parameter. A `true` value means that the transaction is consistent. |
+| `state` | State of the given transactions in the `tails` parameter. A `true` value means that all given transactions are consistent. A `false` value means that one or more of the given transactions aren't consistent. |
 | `info` | If the `state` field is false, this field contains information about why the transaction is inconsistent |
 | `duration` | Number of milliseconds it took to complete the request |
 

--- a/the-tangle/0.1/doc-index.md
+++ b/the-tangle/0.1/doc-index.md
@@ -6,7 +6,7 @@
 
 [Concepts/Tip selection](/concepts/tip-selection.md)
 
-[Concepts/Incentives-in-the-Tangle](/concepts/incentives-in-the-tangle.md)
+[Concepts/Incentives in the Tangle](/concepts/incentives-in-the-tangle.md)
 
 [Concepts/Proof of work](/concepts/proof-of-work.md)
 


### PR DESCRIPTION
Fix an error in the description of the returned `states` field. One state is always returns no matter how many transaction hashes are included in the `tails` parameter.