### PR TITLE
Fix links

### DIFF
--- a/smartcity/0.1/doc-index.md
+++ b/smartcity/0.1/doc-index.md
@@ -2,7 +2,7 @@
 
 [Introduction/Overview](/introduction/overview.md)
 [AstroPiOTA/Overview](astropiota/introduction/overview.md)
-[AstroPiOTA/Build](astropiota/how-to-guides/buildIt.md)
-[AstroPiOTA/Install](astropiota/how-to-guides/installIt.md)
+[AstroPiOTA/Build](astropiota/how-to-guides/BuildIT.md)
+[AstroPiOTA/Install](astropiota/how-to-guides/InstallIT.md)
 [AstroPiOTA/Run](astropiota/how-to-guides/Headless.md)
-[AstroPiOTA/Customize](astropiota/how-to-guides/customizeIt.md)
+[AstroPiOTA/Customize](astropiota/how-to-guides/CustomizeIT.md)

--- a/smartcity/0.1/doc-index.md
+++ b/smartcity/0.1/doc-index.md
@@ -2,7 +2,7 @@
 
 [Introduction/Overview](/introduction/overview.md)
 [AstroPiOTA/Overview](astropiota/introduction/overview.md)
-[AstroPiOTA/Build](astropiota/how-to-guides/buildit.md)
-[AstroPiOTA/Install](astropiota/how-to-guides/installit.md)
-[AstroPiOTA/Run](astropiota/how-to-guides/headless.md)
-[AstroPiOTA/Customize](astropiota/how-to-guides/customizeit.md)
+[AstroPiOTA/Build](astropiota/how-to-guides/buildIt.md)
+[AstroPiOTA/Install](astropiota/how-to-guides/installIt.md)
+[AstroPiOTA/Run](astropiota/how-to-guides/Headless.md)
+[AstroPiOTA/Customize](astropiota/how-to-guides/customizeIt.md)


### PR DESCRIPTION
Ideally, all links should be lowercase to be consistent. This fixes the build errors, but we should go though and update the file names.