### PR TITLE
Disable remote page checking in pre-commit

### DIFF
--- a/buildProjects.js
+++ b/buildProjects.js
@@ -10,6 +10,8 @@ const chalk = require('chalk');
 
 const { rootFolder, reportFile, projectsFile, checkRemotePages, checkSpelling, spellingFile, consoleDetail, exitWithError } = require('./buildProjects.config.json');
 
+let remoteCheck = checkRemotePages;
+
 let md;
 let spellchecker;
 let cheerio;
@@ -670,7 +672,7 @@ function sanitizeLink(item) {
 }
 
 async function checkRemote(url) {
-    if (checkRemotePages) {
+    if (remoteCheck) {
         try {
             await axios.head(url);
         } catch (err) {
@@ -740,7 +742,14 @@ async function run(singleProject) {
 
 console.log(chalk.green.underline.bold('Build Projects'));
 
-const singleProject = process.argv[2] || '';
+let singleProject = '';
+for (let i = 2; i < process.argv.length; i++) {
+    if (process.argv[i] === '--no-remote') {
+        remoteCheck = false;
+    } else {
+        singleProject = process.argv[i];
+    }
+}
 
 run(singleProject)
     .then(() => console.log(chalk.green(`\n${emoji.get('smile')}  Completed Successfully`)))

--- a/buildProjects.js
+++ b/buildProjects.js
@@ -654,7 +654,7 @@ function listDirs(dir) {
 function fileExistsWithCaseSync(file) {
     const dir = path.dirname(file);
 
-    if (dir === '/' || dir === '.' || dir.indexOf(":") >= 0) {
+    if (dir === '/' || dir === '.' || dir.indexOf(':') >= 0) {
         return true;
     }
 

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
         "url": "https://github.com/iotaledger/documentation/issues"
     },
     "scripts": {
-        "validate": "node buildProjects.js"
+        "validate": "node buildProjects.js --no-remote"
     },
     "pre-commit": [ "validate" ],
     "homepage": "https://github.com/iotaledger/documentation#readme",


### PR DESCRIPTION
Disable remote page checking in pre-commit using `--no-remote` command line option which overrides the `checkRemotePages` setting in `buildProjects.config.json`