### PR TITLE
Add article about MWM to IOTA basics

### DIFF
--- a/getting-started/0.1/references/iota-networks.md
+++ b/getting-started/0.1/references/iota-networks.md
@@ -33,7 +33,7 @@ On this network, you can test your applications and build proof of concepts that
 
 ### Minimum weight magnitude
 
-Transactions on the Mainnet must use a [minimum weight magnitude](root://iota-basics/0.1/concepts/minimum-weight-magnitude.md) (MWM) of 9 to be valid. Compared to the Mainnet, this MWM reduces the time it takes for [proof of work](root://the-tangle/0.1/concepts/proof-of-work.md) (PoW) to be completed.
+Transactions on the Devnet must use a [minimum weight magnitude](root://iota-basics/0.1/concepts/minimum-weight-magnitude.md) (MWM) of 9 to be valid. Compared to the Mainnet, this MWM reduces the time it takes for [proof of work](root://the-tangle/0.1/concepts/proof-of-work.md) (PoW) to be completed.
 
 ### IRI nodes
 
@@ -73,7 +73,7 @@ On this network, you can test your applications and build proof of concepts that
 
 ### Minimum weight magnitude
 
-Transactions on the Mainnet must use a [minimum weight magnitude](root://iota-basics/0.1/concepts/minimum-weight-magnitude.md) (MWM) of 7 to be valid. Compared to the Mainnet, this MWM reduces the time it takes for [proof of work](root://the-tangle/0.1/concepts/proof-of-work.md) (PoW) to be completed.
+Transactions on the Spamnet must use a [minimum weight magnitude](root://iota-basics/0.1/concepts/minimum-weight-magnitude.md) (MWM) of 7 to be valid. Compared to the Mainnet, this MWM reduces the time it takes for [proof of work](root://the-tangle/0.1/concepts/proof-of-work.md) (PoW) to be completed.
 
 ### IRI nodes
 

--- a/getting-started/0.1/references/iota-networks.md
+++ b/getting-started/0.1/references/iota-networks.md
@@ -2,22 +2,26 @@
 
 **An IOTA network consists of nodes that are mutually connected to neighbors.**
 
-IOTA has the following [permissionless networks](../introduction/what-is-dlt.md) that anyone can use:
+IOTA has the following [permissionless networks](../introduction/what-is-dlt.md):
 * **Mainnet:** IOTA token
 * **Devnet:** Devnet token (free)
 * **Spamnet:** Spamnet token (free)
 
-All permissionless networks consist of IRI nodes, clients, and the Coordinator.
+All permissionless networks consist of nodes, clients, and the Coordinator.
 
-If you want to create and test an application on a permissioned (private) network, you can do so by running an instance of the open-source Coordinator called [Compass](root://compass/0.1/introduction/overview.md).
+:::info:
+If you want to create and test an application on a permissioned (private) network, you can do so by running an instance of the open-source Coordinator code called [Compass](root://compass/0.1/introduction/overview.md).
+:::
 
 ## Mainnet
 
-When you buy IOTA tokens from a cryptocurrency exchange, you can send those token to addresses on the Mainnet.
-
-Transactions on the Mainnet must use a MWM (minimum weight magnitude) of 14 to be valid.
+When you buy IOTA tokens from a cryptocurrency exchange, those tokens are valid on the Mainnet.
 
 ![Mainnet configuration](../mainnet-configuration.png)
+
+### Minimum weight magnitude
+
+Transactions on the Mainnet must use a [minimum weight magnitude](root://iota-basics/0.1/concepts/minimum-weight-magnitude.md) (MWM) of 14 to be valid.
 
 ## Devnet
 
@@ -25,9 +29,11 @@ The Devnet is a copy of the Mainnet.
 
 On this network, you can test your applications and build proof of concepts that use [free Devnet tokens](https://faucet.devnet.iota.org). The faucet website will send 1000 Devnet tokens to the specified address.
 
-Transactions on the Devnet must use a MWM (minimum weight magnitude) of 9 to be valid. Compared to the Mainnet, this MWM vastly reduces the time it takes for the Proof of Work (PoW) to be completed.
-
 ![Devnet Configuration](../devnet-configuration.png)
+
+### Minimum weight magnitude
+
+Transactions on the Mainnet must use a [minimum weight magnitude](root://iota-basics/0.1/concepts/minimum-weight-magnitude.md) (MWM) of 9 to be valid. Compared to the Mainnet, this MWM reduces the time it takes for [proof of work](root://the-tangle/0.1/concepts/proof-of-work.md) (PoW) to be completed.
 
 ### IRI nodes
 
@@ -63,9 +69,11 @@ The Spamnet is for applications that spam transactions.
 
 On this network, you can test your applications and build proof of concepts that use [free Spamnet tokens](https://faucet.spamnet.iota.org).
 
-Transactions on the Devnet must use a MWM (minimum weight magnitude) of 7 to be valid. Compared to the Mainnet, this MWM vastly reduces the time it takes for the Proof of Work (PoW) to be completed.
+![Spamnet configuration](../spamnet-topology.png)
 
-![Topology of the Spamnet](../spamnet-topology.png)
+### Minimum weight magnitude
+
+Transactions on the Mainnet must use a [minimum weight magnitude](root://iota-basics/0.1/concepts/minimum-weight-magnitude.md) (MWM) of 7 to be valid. Compared to the Mainnet, this MWM reduces the time it takes for [proof of work](root://the-tangle/0.1/concepts/proof-of-work.md) (PoW) to be completed.
 
 ### IRI nodes
 

--- a/hub/0.1/references/command-line-flags.md
+++ b/hub/0.1/references/command-line-flags.md
@@ -41,7 +41,7 @@
 |`--authProvider`| Provider to use to authenticate the [`signBundle`](../references/api-reference.md#hub.rpc.SignBundleRequest) method. This value can be "non" or "hmac"| "none"|
 |`--depth`|Value to use for the `depth` parameter of the [`getTransactionsToApprove` (GTTA)](root://iri/0.1/references/api-reference.md#getTransactionsToApprove) endpoint| 3|
 |`--hmacKeyPath` |Path to the HMAC key used to authenticate the [`signBundle`](../references/api-reference.md#hub.rpc.SignBundleRequest) method|"/dev/null"|
-|`--minWeightMagnitude`| [Minimum weight magnitude (MWM)](root://the-tangle/0.1/concepts/proof-of-work.md) to use for proof of work. To use Hub on the Mainnet, you must use a MWM of 14.| 9|
+|`--minWeightMagnitude`| [Minimum weight magnitude (MWM)](root://iota-basics/0.1/concepts/minimum-weight-magnitude.md) to use for proof of work. To use Hub on the Mainnet, you must use a MWM of 14.| 9|
 |<a name="monitorInterval"></a>`--monitorInterval`|Interval in milliseconds that Hub checks deposit addresses and updates the [`user_address` and `user_address_balance` tables](../references/database-tables.md). Those that contain tokens are included in the next sweep. 0=disabled.|60000|
 |`--signingMode`|Method to use to sign bundles. This value can be "local" or "remote" (if you run a signing server) |"local"|
 |`--signingProviderAddress`|URL or IP address of the signing server. Where you have the "remote" value for the `--signingMode`, you must also use this flag.|"0.0.0.0:50052"|

--- a/iota-basics/0.1/concepts/minimum-weight-magnitude.md
+++ b/iota-basics/0.1/concepts/minimum-weight-magnitude.md
@@ -8,7 +8,7 @@ If a transaction ends in fewer 0 trits, the nodes in that network will reject it
 
 For example, on the Mainnet, the MWM is 14. So, all transaction hashes must end in that number of 0 trits.
 
-If you were to send a transaction whose hash ends in 9 (the MWM on the Devnet) 0 trits, no nodes on the Mainnet would accept it.  
+If you were to send a transaction whose hash ends in 9 (the MWM on the Devnet) or 7 (the MWM on the Spamnet) 0 trits, no nodes on the Mainnet would accept it.
 
 :::info:
 Every increment of the MWM triples the difficulty of the PoW.

--- a/iota-basics/0.1/concepts/minimum-weight-magnitude.md
+++ b/iota-basics/0.1/concepts/minimum-weight-magnitude.md
@@ -1,0 +1,15 @@
+### Minimum weight magnitude
+
+**The minimum weight magnitude (MWM) is a variable that defines how much work is done during proof of work. During proof of work, the transaction hash is repeatedly hashed until it ends in the same number of 0 trits as the MWM. The higher the MWM, the harder the proof of work. When you interact with an IOTA network as a client, you must use the correct MWM. Otherwise, your transaction won't be valid and the nodes will reject it.**
+
+All nodes in an [IOTA network](root://getting-started/0.1/references/iota-networks.md) accept transactions whose hashes end in the same number of 0 trits as their predefined MWM.
+
+If a transaction ends in fewer 0 trits, the nodes in that network will reject it.
+
+For example, on the Mainnet, the MWM is 14. So, all transaction hashes must end in that number of 0 trits.
+
+If you were to send a transaction whose hash ends in 9 (the MWM on the Devnet) 0 trits, no nodes on the Mainnet would accept it.  
+
+:::info:
+Every increment of the MWM triples the difficulty of the PoW.
+:::

--- a/iota-basics/0.1/concepts/minimum-weight-magnitude.md
+++ b/iota-basics/0.1/concepts/minimum-weight-magnitude.md
@@ -1,8 +1,8 @@
-### Minimum weight magnitude
+# Minimum weight magnitude
 
-**The minimum weight magnitude (MWM) is a variable that defines how much work is done during proof of work. During proof of work, the transaction hash is repeatedly hashed until it ends in the same number of 0 trits as the MWM. The higher the MWM, the harder the proof of work. When you interact with an IOTA network as a client, you must use the correct MWM. Otherwise, your transaction won't be valid and the nodes will reject it.**
+**The minimum weight magnitude (MWM) is a variable that defines how much work is done during proof of work. During proof of work, the transaction hash is repeatedly hashed until it ends in the same number of 0 trits as the MWM. The higher the MWM, the harder the proof of work. When you interact with an IOTA network as a client, you must use the correct MWM for that network. Otherwise, your transaction won't be valid and the nodes will reject it.**
 
-All nodes in an [IOTA network](root://getting-started/0.1/references/iota-networks.md) accept transactions whose hashes end in the same number of 0 trits as their predefined MWM.
+All nodes in an [IOTA network](root://getting-started/0.1/references/iota-networks.md) accept transactions whose hashes end in the same or higher number of 0 trits as their predefined MWM.
 
 If a transaction ends in fewer 0 trits, the nodes in that network will reject it.
 

--- a/iota-basics/0.1/doc-index.md
+++ b/iota-basics/0.1/doc-index.md
@@ -6,6 +6,8 @@
 
 [Concepts/Bundles and transactions](/concepts/bundles-and-transactions.md)
 
+[Concepts/Minimum weight magnitude](/concepts/minimum-weight-magnitude.md)
+
 [Concepts/Reattach, rebroadcast, and promote](/concepts/reattach-rebroadcast-promote.md)
 
 [Concepts/Trinary](/concepts/trinary.md)

--- a/the-tangle/0.1/concepts/proof-of-work.md
+++ b/the-tangle/0.1/concepts/proof-of-work.md
@@ -22,7 +22,7 @@ To calculate the PoW for a transaction, the following [contents of the transacti
 * **Signature:** Signature of the transaction (if it withdraws IOTA tokens from an address)
 * **Trunk transaction and branch transaction:** Two transactions that the transaction references and approves
 
-If the transaction hash ends in the correct number of 0 trits ([minimum weight magnitude](#minimum-weight-magnitude)), it's considered valid.
+If the transaction hash ends in the correct number of 0 trits ([minimum weight magnitude](root://iota-basics/0.1/concepts/minimum-weight-magnitude.md)), it's considered valid.
 
 :::info:
 [Three 0 trits are encoded to a 9 in trytes](root://iota-basics/0.1/references/tryte-alphabet.md).
@@ -47,14 +47,4 @@ Because the the contents of the transaction are hashed, if any of the contents c
 
 :::info:
 The function that calculates PoW is called the [PearlDiver](https://github.com/iotaledger/iri/blob/fcf2d105851ee891b093e2857592fa05258ec5be/src/main/java/com/iota/iri/crypto/PearlDiver.java).
-:::
-
-### Minimum weight magnitude
-
-The minimum weight magnitude (MWM) is a variable that defines the number of 0 trits that a transaction hash must end in.
-
-Although the MWM is set in the node software ([IRI](root://iri/0.1/introduction/overview.md)) of each node in an IOTA network, clients and nodes can choose to change the MWM. However, if each node were to use a different MWM, transactions would be valid only for those nodes with the same MWM. This situation would decrease the rate of transaction confirmations.
-
-:::info:
-Every increment of the MWM increases the difficulty of the PoW by 3 times.
 :::


### PR DESCRIPTION
Choosing a minimum weight magnitude is something we don't really explain in our how-to guides.

Having this article allows us to link to it whenever we connect to a node using a particular MWM.