### PR TITLE
Make terminology consistent - spent addresses

### DIFF
--- a/hub/0.1/concepts/sweeps.md
+++ b/hub/0.1/concepts/sweeps.md
@@ -1,21 +1,21 @@
 # Sweeps
 
-**A sweep is a bundle that actions users' withdrawals and transfers IOTA tokens from users' deposit addresses to one of the Hub owner's addresses. Sweeps are an optional safety feature that reduces the likelihood of an attacker stealing tokens from a used address.**
+**A sweep is a bundle that actions users' withdrawals and transfers IOTA tokens from users' deposit addresses to one of the Hub owner's addresses. Sweeps are an optional safety feature that reduces the likelihood of an attacker stealing tokens from a spent address.**
 
 IOTA uses the Winternitz one-time signature scheme to create signatures. As a result, each signature exposes around half of the private key. Signing a bundle once with the a private key is safe. Signing a different bundle with the same private key may allow attackers to brute force the private key and steal IOTA tokens from the address. So, when a user withdraws from an address, that address is considered 'used' and must never be withdrawn from again.
 
-If a user deposits IOTA tokens into a used address such as one involved in a sweep, the tokens in that address are at risk of being stolen.
+If a user deposits IOTA tokens into a spent address such as one involved in a sweep, the tokens in that address are at risk of being stolen.
 
 Hub reduces this risk by transferring IOTA tokens from users' deposit addresses to a Hub owner's address at regular intervals.
 
 :::danger:Important
-You shouldn't rely on sweeps to protect used addresses. An attacker could steal the funds before Hub can do a sweep.
+You shouldn't rely on sweeps to protect spent addresses. An attacker could steal the funds before Hub can do a sweep.
 
-So, it's important that you inform users never to deposit tokens into a used address.
+So, it's important that you inform users never to deposit tokens into a spent address.
 :::
 
 :::info:
-[Discover the details about address reuse and why you must never do it](root://iota-basics/0.1/concepts/addresses-and-signatures.md#address-reuse).
+[Discover the details about spent addresses and why you must never withdraw from an address more than once](root://iota-basics/0.1/concepts/addresses-and-signatures.md#address-reuse).
 :::
 
 To do a sweep, Hub does the following at regular intervals that are defined by the [`--monitorInterval` and `--sweepInterval`](../references/command-line-flags.md#monitorInterval) flags:

--- a/hub/0.1/introduction/overview.md
+++ b/hub/0.1/introduction/overview.md
@@ -35,13 +35,13 @@ For extra security you should [install a signing server](../how-to-guides/instal
 
 ## Token protection
 
-IOTA uses the Winternitz one-time signature scheme to create signatures. As a result, each signature exposes around half of the private key. Signing a bundle once with the a private key is safe. So, when a user withdraws from an address, that address is considered 'used' and must never be withdrawn from again.
+IOTA uses the Winternitz one-time signature scheme to create signatures. As a result, each signature exposes around half of the private key. Signing a bundle once with the a private key is safe. So, when a user withdraws from an address, that address is considered 'spent' and must never be withdrawn from again.
 
 :::info:
-[Discover the details about address reuse and why you must never do it](root://iota-basics/0.1/concepts/addresses-and-signatures.md#address-reuse).
+[Discover the details about spent addresses and why you must never withdraw from an address more than once](root://iota-basics/0.1/concepts/addresses-and-signatures.md#address-reuse).
 :::
 
-To help stop address reuse, Hub has the following features:
+To help users not to withdraw from spent addresses, Hub has the following features:
 
 **Withdrawal management:** Before withdrawing tokens from a user's address, Hub makes sure that no deposit transactions are pending for that same address, and that all previous deposit transactions have been confirmed. To keep track of which addresses have been withdrawn from, Hub stores the addresses in the database. When an address has been withdrawn from, Hub stops users from withdrawing from that address again.
  
@@ -51,9 +51,9 @@ To help stop address reuse, Hub has the following features:
 
 ## Limitations
 
-Hub helps to stop address reuse, but it doesn't stop users from depositing into a used address.
+Hub helps to stop users from withdrawing from spent addresses, but it doesn't stop users from depositing into them.
 
-If a user deposits tokens into a used address, you can use the gRPC API to [create a bundle that withdraws those tokens](https://github.com/iotaledger/rpchub/blob/master/docs/hip/001-sign_bundle.md).
+If a user deposits tokens into a spent address, you can use the gRPC API to [create a bundle that withdraws those tokens](https://github.com/iotaledger/rpchub/blob/master/docs/hip/001-sign_bundle.md).
 
 ## Repository
 

--- a/hub/0.1/references/database-tables.md
+++ b/hub/0.1/references/database-tables.md
@@ -49,7 +49,7 @@ This table contains the seed UUIDs for addresses that have been withdrawn from (
 
 | **Field**       | **Description**          | **Default**|
 |:----------------|:--------------------------|:--------|
-|`uuid`|Seed UUID for the used address| NULL|
+|`uuid`|Seed UUID for the spent address| NULL|
 
 ## Sweep
 

--- a/hub/0.1/references/security-considerations.md
+++ b/hub/0.1/references/security-considerations.md
@@ -9,9 +9,9 @@ For [security purposes](root://iota-basics/0.1/concepts/addresses-and-signatures
 Hub reduces this risk by transferring IOTA tokens from users' deposit addresses to a Hub owner's address at regular intervals. This process happens in a [sweep](../concepts/sweeps.md).
 
 :::danger:Important
-You shouldn't rely on sweeps to protect used addresses. An attacker could steal the funds before Hub can do a sweep.
+You shouldn't rely on sweeps to protect spent addresses. An attacker could steal the funds before Hub can do a sweep.
 
-So, it's important that you inform users never to deposit tokens into a used address.
+So, it's important that you inform users never to deposit tokens into a spent address.
 :::
 
 ## Salt

--- a/hub/home.md
+++ b/hub/home.md
@@ -4,7 +4,7 @@
 ## Learn what Hub can do and where to get started
 
 [Sweeps](/0.1/concepts/sweeps.md)
-## Learn how sweeps add a layer of security to protect used addresses
+## Learn how sweeps add a layer of security to protect spent addresses
 
 [Install Hub](/0.1/how-to-guides/install-hub.md)
 ## Create a multi-user wallet, connect it to an IRI node, and test it

--- a/iota-basics/0.1/concepts/addresses-and-signatures.md
+++ b/iota-basics/0.1/concepts/addresses-and-signatures.md
@@ -10,10 +10,10 @@ Each private key is unique to a seed, index, and security level, and can be used
 
 Each pair of private keys and addresses has its own index and [security level](../references/security-levels.md). The security level affects the length of the private key. The higher the security level, the longer the private key, and the more secure a transaction's signature.
 
-In IOTA, multiple pairs of private keys and addresses are needed because [each address can be withdrawn from only once](#address-reuse). So, each time you withdraw from an address, you must [create a new address](../how-to-guides/create-an-address.md) by either incrementing the index or changing the security level.
+In IOTA, multiple pairs of private keys and addresses are needed because [each address can be withdrawn from (spent) only once](#address-reuse). So, each time you withdraw from an address, you must [create a new address](../how-to-guides/create-an-address.md) by either incrementing the index or changing the security level.
 
 :::info:
-The higher the security level of a private key and address pair, the more difficult it is for an attacker to brute force the signature of a reused address.
+The higher the security level of a private key and address pair, the more difficult it is for an attacker to brute force the signature of a spent address.
 :::
 
 :::warning:Keep seeds and private keys secure
@@ -57,10 +57,12 @@ By signing the bundle hash, it's impossible for attackers to intercept a bundle 
 Signatures are created using the Winternitz one-time signature scheme (W-OTS). This signature scheme is quantum resistant, meaning that signatures are resistant to attacks from [quantum computers](https://en.wikipedia.org/wiki/Quantum_computing).
 
 To sign a bundle hash, first it's normalized to make sure that only half of the private key is revealed in the signature.
+
+If the bundle hash weren't normalized, the W-OTS would reveal an unknown amount of the private key. By revealing half of the private key, an address can safely be withdrawn from once.
 <a id="address-reuse"></a>
 
-:::danger:Address reuse
-If the bundle hash weren't normalized, the W-OTS would reveal an unknown amount of the private key. By revealing half of the private key, an address can safely be withdrawn from once. If an address is withdrawn from more than once, more of the private key is revealed, so an attacker could brute force its signature and steal the IOTA tokens.
+:::danger:Spent addresses
+If an address is withdrawn from (spent) more than once, more of the private key is revealed, so an attacker could brute force its signature and steal the IOTA tokens.
 :::
 
 Depending on the number of key fragments that a private key has, 27, 54, or 81 trytes of the normalized bundle hash are selected. These trytes correspond to the number of segments in a key fragment.

--- a/iota-basics/0.1/concepts/bundles-and-transactions.md
+++ b/iota-basics/0.1/concepts/bundles-and-transactions.md
@@ -14,7 +14,9 @@ You're at an online checkout and the total to pay is 10Mi. Your seed has 2 addre
 
 For the vendor to receive 10Mi, all three of those transactions must be valid. They're sequential instructions that rely on each other's validity to achieve the overall goal of transferring IOTA tokens.
 
-**Note:** It's not just multiple transactions that need to be packaged in a bundle, even individual ones do.
+:::info:
+It's not just multiple transactions that need to be packaged in a bundle, even individual ones do.
+:::
 
 ## Withdrawals and deposits
 
@@ -26,7 +28,9 @@ Input transactions withdraw IOTA tokens from addresses.
 
 Bundles can contain multiple input transactions, and each one must include a valid signature. The length of the signature depends on the [security level](../references/security-levels.md) of the address. If the security level of the address is greater than 1, the signature is too large to fit in one transaction and must be fragmented across zero-value output transactions.
 
-**Important:** [Addresses must not be withdrawn from more than once](../concepts/addresses-and-signatures.md#address-reuse). Therefore, input transactions must withdraw all IOTA tokens from an address even if the sender does not want to transfer all of them to the recipient. The remaining IOTA tokens can be deposited into a remainder address (usually the sender's address) in an output transaction.
+:::danger:
+[Addresses must not be withdrawn from more than once](../concepts/addresses-and-signatures.md#address-reuse). Therefore, input transactions must withdraw all IOTA tokens from an address even if the sender does not want to transfer all of them to the recipient. The remaining IOTA tokens can be deposited into a remainder address (usually the sender's address) in an output transaction.
+:::
 
 ### Output transaction
 
@@ -37,7 +41,9 @@ Output transactions can be one of the following:
 
 Bundles can contain multiple output transactions. If a message in an output transaction is larger than the `signatureMessageFragment` field, the message can be fragmented across other zero-value output transactions.
 
-**Note:** Transactions that deposit IOTA tokens can also contain a message because they don't withdraw IOTA tokens, and therefore don't contain a signature.
+:::info:
+Transactions that deposit IOTA tokens can also contain a message because they don't withdraw IOTA tokens, and therefore don't contain a signature.
+:::
 
 ## How bundles are validated
 

--- a/iota-go/0.1/how-to-guides/create-and-manage-cda.md
+++ b/iota-go/0.1/how-to-guides/create-and-manage-cda.md
@@ -2,7 +2,7 @@
 
 **To send and receive transactions in an account, you must use conditional deposit addresses (CDA). CDAs are special addresses that allow you to specify the conditions in which they may be used in account withdrawals and deposits.**
 
-Accounts use CDAs to avoid address reuse. When you request IOTA tokens from a someone, you can create a CDA that's active for a certain period of time. This way, you let the sender know that you intend to withdraw from that address only after that time. As a result, the sender can decide whether to make a deposit, depending on how much time is left on a CDA.
+Accounts use CDAs to reduce the [risks associated with spent addresses](root://iota-basics/0.1/concepts/addresses-and-signatures.md#address-reuse). When you request IOTA tokens from a someone, you can create a CDA that's active for a certain period of time. This way, you let the sender know that you intend to withdraw from that address only after that time. As a result, the sender can decide whether to make a deposit, depending on how much time is left on a CDA.
 
 :::info:
 CDAs can be used only in an account and not in the generic [client library methods](root://client-libraries/0.1/introduction/overview.md). As a result, both you and the sender must have an account to be able to use CDAs.
@@ -32,7 +32,7 @@ You can't specify the `expected_amount` and `multi_use` fields in the same CDA. 
 :::warning:Warning
 If a CDA was created with only the `timeout_at` field, it can be used in withdrawals as soon as it has a non-zero balance even if it hasn't expired. 
 
-To avoid address reuse, we recommend creating CDAs with either the `multi_use` field or with the `expected_amount` field whenever possible.
+To avoid withdrawing from a spent address, we recommend creating CDAs with either the `multi_use` field or with the `expected_amount` field whenever possible.
 :::
 
 ## Prerequisites

--- a/iota-go/0.1/references/cda-faq.md
+++ b/iota-go/0.1/references/cda-faq.md
@@ -5,7 +5,7 @@
 The value that you specify in the `timeout_at` field depends on how fast you expect the depositor to make a deposit. If you are in direct contact with the depositor and you are both waiting to settle the transfer, you can specify a shorter timeout.
 
 :::danger:Important
-If a CDA was created with only the `timeout_at` field, it can be used in withdrawals as soon as it has a non-zero balance even if it hasn't expired. So, to avoid address reuse, we recommend creating CDAs with either the `multi_use` field or with the `expected_amount` field whenever possible.
+If a CDA was created with only the `timeout_at` field, it can be used in withdrawals as soon as it has a non-zero balance even if it hasn't expired. So, to avoid withdrawing from a spent address, we recommend creating CDAs with either the `multi_use` field or with the `expected_amount` field whenever possible.
 :::
 
 ## When should I create a multi-use CDA?

--- a/iota-java/0.1/how-to-guides/create-and-manage-cda.md
+++ b/iota-java/0.1/how-to-guides/create-and-manage-cda.md
@@ -2,7 +2,7 @@
 
 **To send and receive transactions in an account, you must use conditional deposit addresses (CDA). CDAs are special addresses that allow you to specify the conditions in which they may be used in account withdrawals and deposits.**
 
-Accounts use CDAs to avoid address reuse. When you request IOTA tokens from a someone, you can create a CDA that's active for a certain period of time. This way, you let the sender know that you intend to withdraw from that address only after that time. As a result, the sender can decide whether to make a deposit, depending on how much time is left on a CDA.
+Accounts use CDAs to help reduce the [risks of withdrawing from spent addresses](root://iota-basics/0.1/concepts/addresses-and-signatures.md#address-reuse). When you request IOTA tokens from a someone, you can create a CDA that's active for a certain period of time. This way, you let the sender know that you intend to withdraw from that address only after that time. As a result, the sender can decide whether to make a deposit, depending on how much time is left on a CDA.
 
 :::info:
 CDAs can be used only in an account and not in the generic [client library methods](root://client-libraries/0.1/introduction/overview.md). As a result, both you and the sender must have an account to be able to use CDAs.
@@ -40,7 +40,7 @@ You can't specify the `expected_amount` and `multi_use` fields in the same CDA. 
 :::warning:Warning
 If a CDA was created with only the `timeout_at` field, it can be used in withdrawals as soon as it has a non-zero balance even if it hasn't expired. 
 
-To avoid address reuse, we recommend creating CDAs with either the `multi_use` field or with the `expected_amount` field whenever possible.
+To avoid withdrawing from a spent address, we recommend creating CDAs with either the `multi_use` field or with the `expected_amount` field whenever possible.
 :::
 
 ## Create a CDA

--- a/iota-java/0.1/references/cda-faq.md
+++ b/iota-java/0.1/references/cda-faq.md
@@ -5,7 +5,7 @@
 The value that you specify in the `timeout_at` field depends on how fast you expect the depositor to make a deposit. If you are in direct contact with the depositor and you are both waiting to settle the transfer, you can specify a shorter timeout.
 
 :::danger:Important
-If a CDA was created with only the `timeout_at` field, it can be used in withdrawals as soon as it has a non-zero balance even if it hasn't expired. So, to avoid address reuse, we recommend creating CDAs with either the `multi_use` field or with the `expected_amount` field whenever possible.
+If a CDA was created with only the `timeout_at` field, it can be used in withdrawals as soon as it has a non-zero balance even if it hasn't expired. So, to avoid withdrawing from a spent address, we recommend creating CDAs with either the `multi_use` field or with the `expected_amount` field whenever possible.
 :::
 
 ## When should I create a multi-use CDA?

--- a/iota-js/0.1/how-to-guides/create-and-manage-cda.md
+++ b/iota-js/0.1/how-to-guides/create-and-manage-cda.md
@@ -2,7 +2,7 @@
 
 **To send and receive transactions in an account, you must use conditional deposit addresses (CDA). CDAs are special addresses that allow you to specify the conditions in which they may be used in account withdrawals and deposits.**
 
-Accounts use CDAs to avoid address reuse. When you request IOTA tokens from a someone, you can create a CDA that's active for a certain period of time. This way, you let the sender know that you intend to withdraw from that address only after that time. As a result, the sender can decide whether to make a deposit, depending on how much time is left on a CDA.
+Accounts use CDAs to help reduce the [risks of withdrawing from spent addresses](root://iota-basics/0.1/concepts/addresses-and-signatures.md#address-reuse). When you request IOTA tokens from a someone, you can create a CDA that's active for a certain period of time. This way, you let the sender know that you intend to withdraw from that address only after that time. As a result, the sender can decide whether to make a deposit, depending on how much time is left on a CDA.
 
 :::info:
 CDAs can be used only in an account and not in the generic [client library methods](root://client-libraries/0.1/introduction/overview.md). As a result, both you and the sender must have an account to be able to use CDAs.
@@ -40,7 +40,7 @@ You can't specify the `expected_amount` and `multi_use` fields in the same CDA. 
 :::warning:Warning
 If a CDA was created with only the `timeoutAt` field, it can be used in withdrawals as soon as it has a non-zero balance even if it hasn't expired. 
 
-To avoid address reuse, we recommend creating CDAs with either the `multiUse` field or with the `expectedAmount` field whenever possible.
+To avoid withdrawing from a spent address, we recommend creating CDAs with either the `multiUse` field or with the `expectedAmount` field whenever possible.
 :::
 
 ## Create a CDA

--- a/iota-js/0.1/references/cda-faq.md
+++ b/iota-js/0.1/references/cda-faq.md
@@ -5,7 +5,7 @@
 The value that you specify in the `timeout_at` field depends on how fast you expect the depositor to make a deposit. If you are in direct contact with the depositor and you are both waiting to settle the transfer, you can specify a shorter timeout.
 
 :::danger:Important
-If a CDA was created with only the `timeout_at` field, it can be used in withdrawals as soon as it has a non-zero balance even if it hasn't expired. So, to avoid address reuse, we recommend creating CDAs with either the `multi_use` field or with the `expected_amount` field whenever possible.
+If a CDA was created with only the `timeout_at` field, it can be used in withdrawals as soon as it has a non-zero balance even if it hasn't expired. So, to avoid withdrawing from a spent address, we recommend creating CDAs with either the `multi_use` field or with the `expected_amount` field whenever possible.
 :::
 
 ## When should I create a multi-use CDA?

--- a/trinity/0.1/how-to-guides/receive-a-transaction.md
+++ b/trinity/0.1/how-to-guides/receive-a-transaction.md
@@ -3,7 +3,7 @@
 **Trinity has a user interface that allows you to receive transactions and generate new addresses at the click of a button.**
 
 :::danger:Important
-If you send a transaction that withdraws IOTA tokens from one of your addresses, you can't reuse that address. Instead, you must generate a new address.
+If you send a transaction that withdraws IOTA tokens from one of your addresses, you must never withdraw from that address again. Instead, you must generate a new address.
 :::
 
 1. Click **Receive**


### PR DESCRIPTION
The terms 'used address' and 'address reuse' are ambiguous. An address could also be considered 'used' if you deposit into it.

The term 'spent address' is more accurate.