### PR TITLE
Add fetchTransactionMessages config parameter

### DIFF
--- a/hub/0.1/references/command-line-flags.md
+++ b/hub/0.1/references/command-line-flags.md
@@ -50,6 +50,7 @@
 |`--signingServerSslCert`|If you configure Hub to use SSL encryption (`--authMode="ssl"`) and you have a [signing server](../how-to-guides/install-the-signing-server.md), you must pass the path to the SSL certificate to this flag|"/dev/null"|
 |`--sweepInterval` |Interval in milliseconds that Hub waits between sweeps. 0=disabled.|600000|
 |`--powMode`|[Proof of work](root://the-tangle/0.1/concepts/proof-of-work.md) mode, local or remote|
+|`-fetchTransactionMessages`| Whether Hub stores the message of a deposit transaction in the database |false|
 
 ## Flags from hub/service/sweep_service.cc
 

--- a/hub/0.1/references/database-tables.md
+++ b/hub/0.1/references/database-tables.md
@@ -125,6 +125,7 @@ This table contains information about the balance of users' deposit addresses.
 | `reason`       | One of [three reasons](../references/api-reference.md#hub.rpc.HubAddressBalanceReason) for the balance update event    | NULL                |
 | `tail_hash`    | 81-tryte tail transaction hash of the sweep   | NULL                |
 | `sweep`        | ID of the sweep that caused the balance update. This ID is in the `sweep` table.    | NULL                |
+|`message`| Contents (in trytes) of the `signatureMessageFragment` field of the output transaction in a deposit bundle
 | `occured_at`   | Date and time that the balance was updated in the following format: `YYYY-MM-DD HH:MM:SS` |The current date and time|
 
 ## Withdrawal


### PR DESCRIPTION
You can now choose to store the signatureMessageFragment field of a user's deposit transaction in the database.