### PR TITLE
Trinity: Update macOS build verification instructions for notarization

### DIFF
--- a/trinity/0.1/how-to-guides/verify-trinity-desktop.md
+++ b/trinity/0.1/how-to-guides/verify-trinity-desktop.md
@@ -102,10 +102,10 @@ To follow these instructions you need [Xcode Command Line Tools](https://www.ics
 5. Make sure that the following information matches the output of the command (assuming Trinity is in the `/Applications` directory):
 
     * `/Applications/Trinity.app: accepted`
-    * `source=Developer ID`
+    * `source=Notarized Developer ID` (note: for versions earlier than v0.6.0, this may show as `source=Developer ID`)
     * `origin=Developer ID Application: IOTA Stiftung (UG77RJKZHH)`
-    
-    
+
+
 ## Linux operating system
 
 ### Verify the SHA256 hash


### PR DESCRIPTION
Starting with Trinity Desktop v0.6.0, all macOS builds will be notarized by Apple. When verifying that an app will be accepted by Gatekeeper, `spctl` will output different results for a notarized app (see [docs](https://help.apple.com/xcode/mac/current/#/dev1cc22a95c)).