### PR TITLE
Correct minor typo in command - run-the-node.md

### DIFF
--- a/node-software/0.1/goshimmer/how-to-guides/run-the-node.md
+++ b/node-software/0.1/goshimmer/how-to-guides/run-the-node.md
@@ -125,7 +125,7 @@ When you run the node, it joins the network by autopeering with the entry node t
 6. To see the status screen, attach the Docker container by doing the following. Replace the `$ContainerID` placeholder with your container ID.
 
     ```bash
-    docker attack $ContainerID
+    docker attach $ContainerID
     ```
 
 :::success:Congratulations :tada:


### PR DESCRIPTION
Minor typo:

Run a node in a Docker container
Step 2
Point 6

command:
docker attack $ContainerID

should read:
docker attach $ContainerID