### PR TITLE
Add missing parameter

### DIFF
--- a/wallets/0.1/hub/references/restful-api-reference.md
+++ b/wallets/0.1/hub/references/restful-api-reference.md
@@ -516,7 +516,8 @@ Get the history of a user's balance.
 
 |**Parameter** | **Required or Optional**|**Description** |**Type**
 |--|--|--|--|
-| `userId` |Required| The ID of the user | string
+| `userId` |Required| The ID of the user | string|
+| `newerThan` |Optional| The time and date from which to get the user's history. A `0` value means that Hub gets the entire history.|Unix timestamp
 
 ### Examples
 --------------------


### PR DESCRIPTION
GetUserHistory has an optional `newerThan` parameter