### PR TITLE
Remove Content-Length header from JS examples

### DIFF
--- a/blueprints/0.1/p2p-energy/architecture.md
+++ b/blueprints/0.1/p2p-energy/architecture.md
@@ -151,7 +151,7 @@ print jsonData
 ```js
 var request = require('request');
 
-var body = {
+var command = {
    "itemName": "My Solar Source",
    "itemType": "solar",
    "root": "CCCCCC...DDDDDD",
@@ -162,8 +162,7 @@ var options = {
   url: 'https://producer/registration/:registrationId',
   method: 'PUT',
   headers: {
-    'Content-Type': 'application/json',
-    'Content-Length': Buffer.byteLength(JSON.stringify(body))
+    'Content-Type': 'application/json'
   },
   json: command
 };
@@ -383,7 +382,7 @@ print jsonData
 ```js
 var request = require('request');
 
-var body = {
+var command = {
    "itemName": "Jake",
    "itemType": "consumer",
    "root": "CCCCCC...DDDDDD",
@@ -394,8 +393,7 @@ var options = {
   url: 'https://grid/registration/:registrationId',
   method: 'PUT',
   headers: {
-    'Content-Type': 'application/json',
-    'Content-Length': Buffer.byteLength(JSON.stringify(body))
+    'Content-Type': 'application/json'
   },
   json: command
 };
@@ -582,7 +580,7 @@ print jsonData
 ```js
 var request = require('request');
 
-var body = {
+var command = {
    "myCustomData": "Some data"
 }
 
@@ -590,8 +588,7 @@ var options = {
   url: 'https://grid/storage/item/:registration-id/:context/:id',
   method: 'PUT',
   headers: {
-    'Content-Type': 'application/json',
-    'Content-Length': Buffer.byteLength(JSON.stringify(body))
+    'Content-Type': 'application/json'
   },
   json: command
 };

--- a/compass/0.1/how-to-guides/set-up-a-private-tangle.md
+++ b/compass/0.1/how-to-guides/set-up-a-private-tangle.md
@@ -301,8 +301,7 @@ Call the [`getBalances`](root://node-software/0.1/iri/references/api-reference.m
      method: 'POST',
      headers: {
      'Content-Type': 'application/json',
-     'X-IOTA-API-Version': '1',
-     'Content-Length': Buffer.byteLength(JSON.stringify(command))
+     'X-IOTA-API-Version': '1'
      },
      json: command
      };

--- a/node-software/0.1/chronicle/references/api-reference.md
+++ b/node-software/0.1/chronicle/references/api-reference.md
@@ -68,8 +68,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -178,8 +177,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };

--- a/node-software/0.1/iri/how-to-guides/get-started-with-the-api.md
+++ b/node-software/0.1/iri/how-to-guides/get-started-with-the-api.md
@@ -68,8 +68,7 @@ url: 'https://nodes.devnet.iota.org:443',
 method: 'POST',
 headers: {
     'Content-Type': 'application/json',
-    'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
 },
 json: command
 };

--- a/node-software/0.1/iri/references/api-reference.md
+++ b/node-software/0.1/iri/references/api-reference.md
@@ -77,8 +77,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -189,8 +188,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -302,8 +300,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -411,8 +408,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -529,8 +525,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -616,8 +611,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -731,8 +725,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -865,8 +858,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -962,8 +954,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1049,8 +1040,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1149,8 +1139,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1278,8 +1267,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1387,8 +1375,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1496,8 +1483,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1595,8 +1581,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1692,8 +1677,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1791,8 +1775,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1900,8 +1883,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };

--- a/smartcity/0.1/astropiota/how-to-guides/run.md
+++ b/smartcity/0.1/astropiota/how-to-guides/run.md
@@ -87,8 +87,7 @@ Raspbian Jessie comes with NodeRed, which must be removed.
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
-      'X-IOTA-API-Version': '1',
-      'Content-Length': Buffer.byteLength(JSON.stringify(command))
+      'X-IOTA-API-Version': '1'
     },
     json: command
   };

--- a/utils/0.1/community/one-command-tangle/overview.md
+++ b/utils/0.1/community/one-command-tangle/overview.md
@@ -119,8 +119,7 @@ Using the [JavaScript client library](root://client-libraries/0.1/introduction/o
      method: 'POST',
      headers: {
      'Content-Type': 'application/json',
-     'X-IOTA-API-Version': '1',
-     'Content-Length': Buffer.byteLength(JSON.stringify(command))
+     'X-IOTA-API-Version': '1'
      },
      json: command
      };

--- a/wallets/0.1/hub/how-to-guides/get-started-with-rest-api.md
+++ b/wallets/0.1/hub/how-to-guides/get-started-with-rest-api.md
@@ -57,8 +57,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -136,8 +135,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -224,8 +222,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };

--- a/wallets/0.1/hub/references/restful-api-reference.md
+++ b/wallets/0.1/hub/references/restful-api-reference.md
@@ -68,8 +68,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -164,8 +163,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -265,8 +263,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -366,8 +363,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -475,8 +471,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -569,8 +564,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -669,8 +663,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -804,8 +797,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -900,8 +892,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1076,8 +1067,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1191,8 +1181,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1291,8 +1280,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1408,8 +1396,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1514,8 +1501,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1637,8 +1623,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1743,8 +1728,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1848,8 +1832,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };
@@ -1947,8 +1930,7 @@ var options = {
   method: 'POST',
   headers: {
     'Content-Type': 'application/json',
-		'X-IOTA-API-Version': '1',
-    'Content-Length': Buffer.byteLength(JSON.stringify(command))
+    'X-IOTA-API-Version': '1'
   },
   json: command
 };


### PR DESCRIPTION
Remove the `Content-Length` header from the JS examples as it's automatically calculated by `request`.