### PR TITLE
Add information about how ASCII characters are converted to trytes

### DIFF
--- a/getting-started/0.1/introduction/ternary.md
+++ b/getting-started/0.1/introduction/ternary.md
@@ -1,6 +1,6 @@
 # Ternary
 
-**In IOTA, data is represented according to the [ternary numeral system](https://en.wikipedia.org/wiki/Ternary_numeral_system), which consists of trits and trytes. Compared to [binary](https://en.wikipedia.org/wiki/Binary_number), ternary computing is considered to be more efficient as it can represent data in three states rather then just two.**
+**All transactions contain characters called trytes. These trytes are part of the [ternary numeral system](https://en.wikipedia.org/wiki/Ternary_numeral_system). IOTA uses this system because, compared to [binary](https://en.wikipedia.org/wiki/Binary_number), ternary computing is considered to be more efficient as it can represent data in three states rather then just two.**
 
 In IOTA, data is represented in balanced ternary, which consists of 1, 0, or -1. These values are called trits, and three of them are equal to one tryte, which can have 27 (3<sup>3</sup>) possible values.
 
@@ -37,6 +37,66 @@ To make trytes easier to read, they are represented as one of 27 possible tryte-
 |                                  X|  0, -1,  0 |    -3|
 |                                  Y|  1, -1,  0 |    -2|
 |                                  Z| -1,  0,  0 |    -1|
+
+## How ASCII characters are converted to trytes
+
+In the IOTA client libraries, you can convert [ASCII characters](https://en.wikipedia.org/wiki/ASCII) to and from trytes.
+
+This feature is useful for converting an ASCII message such as `Your coffee is ready` to trytes, which you can add to a transaction and attach to the Tangle.
+
+Each ASCII character is represented as 2 trytes by doing the following:
+
+1. Find the decimal Unicode value of an ASCII character
+
+    For example, the decimal Unicode value of `Z` is 90.
+
+2. Use the decimal Unicode value in the following equations:
+
+    ```
+    decimal % 27
+    (decimal - 9) / 27
+    ```
+
+    For example, for `Z`, the result would be
+
+    ```
+    90 % 27 = 9
+    (90 - 9) / 27 = 3
+    ```
+
+3. Use the results of the equations as indices to find the character's tryte value
+
+    |**Index** |**Trytes**|
+    |--|--|
+    |0|9|
+    |1|A|
+    |2|B|
+    |**__3__**|**__C__**|
+    |4|D|
+    |5|E|
+    |6|F|
+    |7|G|
+    |8|H|
+    |**__9__**|**__I__**|
+    |10|J|
+    |11|K|
+    |12|L|
+    |13|M|
+    |14|N|
+    |15|O|
+    |16|P|
+    |17|Q|
+    |18|R|
+    |19|S|
+    |20|T|
+    |21|U|
+    |22|V|
+    |23|W|
+    |24|X|
+    |25|Y|
+    |26|Z|
+
+    For example, the ASCII character `Z` is represented as `IC` in trytes.
 
 ## Utilities
 


### PR DESCRIPTION
This information was hidden in the [code comments of the iota.js library](https://github.com/iotaledger/iota.js/blob/81e4c83a09f53095f931a0ff7b9948985040f9c0/packages/converter/src/ascii.ts).

By moving it to the documentation portal, it's more accessible.