### PR TITLE
Fix java quick start tutorial code

### DIFF
--- a/client-libraries/0.1/getting-started/java-quickstart.md
+++ b/client-libraries/0.1/getting-started/java-quickstart.md
@@ -145,6 +145,7 @@ package com.iota;
 
 import org.iota.jota.IotaAPI;
 import org.iota.jota.dto.response.GetNodeInfoResponse;
+import org.iota.jota.error.ArgumentException;
 
 class ConnectToNode {
 public static void main(String[] args) throws ArgumentException {


### PR DESCRIPTION
When I tried to run the tutorial code, the error showed up because of not importing `ArgumentException` class, so I fixed by importing.