### PR TITLE
Fix missing PlatformIO setup guides in the sidenav

### DIFF
--- a/iot/0.1/doc-index.md
+++ b/iot/0.1/doc-index.md
@@ -32,7 +32,7 @@
 
 [nRF52/Setup Guides/Connect a programmer to your microcontroller](/nrf52/setup-guides/connect-programmer.md)
 
-[nRF52/Setup Guides/Connect to the serial interface to your microcontroller](/nrf52/setup-guides/connect-to-serial-interface.md)
+[nRF52/Setup Guides/Connect to the serial interface of your microcontroller](/nrf52/setup-guides/connect-to-serial-interface.md)
 
 [nRF52/How-to Guides/Read sensor data from your microcontroller](/nrf52/how-to-guides/read-sensor-data.md)
 
@@ -41,6 +41,10 @@
 [nRF52/IOTA Projects/Attach sensor data to the Tangle](/nrf52/iota-projects/run-an-environment-to-tangle-app.md)
 
 [PlatformIO/Introduction/Get started with PlatformIO](/platformio/introduction/get-started.md)
+
+[PlatformIO/Setup Guides/Connect a programmer to your microcontroller](/platformio/setup-guides/connect-programmer-bluepill.md)
+
+[PlatformIO/Setup Guides/Connect to the serial interface of your microcontroller](/platformio/setup-guides/connect-bluepill-serial-interface.md)
 
 [SBC/Introduction/Get started](/sbc/introduction/get-started.md)
 

--- a/iot/0.1/platformio/introduction/get-started.md
+++ b/iot/0.1/platformio/introduction/get-started.md
@@ -8,26 +8,31 @@ To complete this guide you need the following:
 - A 32-bit/64-bit microcontroller device that is supported by Arduino
 - A Linux, macOS, or Windows operating system
 
-## Microcontroller support
-
-Not all devices that are supported by Arduino can be used with IOTA. For a list of restrictions, see the following table
-If your microcontroller is not listed, you can try the code of a [workshop example](https://github.com/iota-community/platformio-arduino-iota-workshop).
-Please post the results of your tests in the #hardware channel on the [IOTA discord](https://discord.iota.org/). 
-
-| Microcontroller | Address generation | Signatures    |
-|-----------------|--------------------|---------------|
-| ESP32           | <= level 2         | <= level 2    |
-| STM32F407VET6   | <= level 2         | <= level 2    |
-| Kendryte k210   | <= level 2         | <= level 2    |
-| STM32F103C6     | level 1            | not supported |
-| nRF52832        | level 1            | not supported |
-| ESP8266         | not supported      | not supported |
-
 In this guide, we use the Arduino framework because it is simple for beginners. However, PlatformIO supports other frameworks such as [mbed OS](https://www.mbed.com/en/platform/mbed-os/) and [Zephyr OS](https://www.zephyrproject.org/), which offer more flexibility and advanced functionality. If you want to use one of these other frameworks, see our [examples](#example-applications).
 
 To check if your device is supported by Arduino, [search for it on the PlatformIO website](https://platformio.org/boards), and make sure that the Frameworks column includes Arduino.
 
 ![PlatformIO device search](../images/platformio-board-search.png)
+
+### Microcontroller support
+
+Not all devices that are supported by Arduino can be used with IOTA. For a list of restrictions, see the following table:
+
+| **Microcontroller** | **Generating addresses** |                **Signing bundles**                 |
+|---------------------|------------------------|------------------------------------------------------|
+| ESP32               | Security levels 1 and 2| Only for addresses with security level 1 and 2       |
+| STM32F407VET6       | Security levels 1 and 2| Only for addresses with security level 1 and 2       |
+| Kendryte k210       | Security levels 1 and 2| Only for addresses with security level 1 and 2       |
+| STM32F103C6         | Security level 1       | Not supported                                        |
+| nRF52832            | Security level 1       | Not supported                                        |
+| ESP8266             | Not supported          | Not supported                                        |
+
+
+If your microcontroller is not listed, do the following:
+- Try our [Arduino workshop example](https://github.com/iota-community/platformio-arduino-iota-workshop)
+- Post your results in the #hardware channel on [Discord](https://discord.iota.org/)
+
+If you're using an STM32F1-series microcontroller, see our [setup guides](../setup-guides/connect-programmer-bluepill.md) before completing this guide.
 
 ## Step 1. Set up a development environment
 

--- a/iot/0.1/platformio/setup-guides/connect-bluepill-serial-interface.md
+++ b/iot/0.1/platformio/setup-guides/connect-bluepill-serial-interface.md
@@ -1,10 +1,10 @@
-# Connect to the bluepills serial interface
+# Connect to the bluepill board's serial interface
 
-**To read the output of your microcontroller, you need to be able to receive and transmit data on its serial port through a USB-to-UART connector. Some microcontroller development boards include an integrated USB-to-UART connector, but others the bluepill does not. In this guide, you connect an external USB-to-UART connector to your bluepill board and plug it into your PC to be able to communicate with the microcontroller.**
+**To read the output of your microcontroller, you need to be able to receive and transmit data on its serial port through a USB-to-UART connector. Some microcontroller development boards include an integrated USB-to-UART connector, but others such as the bluepill board do not. In this guide, you connect an external USB-to-UART connector to your bluepill board and plug it into your PC to be able to communicate with the microcontroller.**
 
 ## Hardware
 
-To complete this guide, you need DuPont cables to connect the USB-to-UART connector to your microcontroller
+To complete this guide, you need DuPont cables, which are used to connect the USB-to-UART connector to your microcontroller
 
 ## Step 1. Choose a USB-to-UART connector
 
@@ -16,7 +16,7 @@ Whichever connector you choose, make sure that it has a [device driver](https://
 
 To use your connector, you need to wire it to your microcontroller.
 
-1. Connect the following pins from the bluepill to the connector
+1. Connect the following pins from the bluepill board to the USB-to-UART connector:
     
     |    **bluepill (pin)**   |    **USB-to-UART**  |
     |------------------|------------------|
@@ -28,9 +28,9 @@ To use your connector, you need to wire it to your microcontroller.
     **USB-to-UART**
 
     :::info:
-    Use a black DuPont cable for GND and a red one for VCC
+    Use a black DuPont cable for GND and a red one for VCC.
     :::
 
-2. Plug the UART-to-USB dongle into your PC
+2. Plug the USB-to-UART connector connector into your PC
 
-If the connections are correct, your PC should detect the connector.
+If the wiring is correct, your PC should detect the connector.

--- a/iot/0.1/platformio/setup-guides/connect-programmer-bluepill.md
+++ b/iot/0.1/platformio/setup-guides/connect-programmer-bluepill.md
@@ -1,6 +1,6 @@
-# Connect to an external programmer to the bluepill board (STM32F1)
+# Connect an external programmer to the bluepill board (STM32F1)
 
-**To transfer machine code onto a microcontroller, you need a [programmer](https://www.engineersgarage.com/how-to-guides/microcontroller-programmer-burner), and not all microcontrollers have an integrated one. In this guide, you connect an external programmer to an STM32F1-series microcontroller.**
+**To transfer machine code onto a microcontroller, you need a [programmer](https://www.engineersgarage.com/how-to-guides/microcontroller-programmer-burner), but not all microcontrollers have an integrated one. In this guide, you connect an external programmer to an STM32F1-series microcontroller.**
 
 ## Hardware
 
@@ -11,23 +11,23 @@ To complete this guide, you need the following:
 
 ## Step 1. Choose an external programmer
 
-You can choose any of the following programmer for the bluepill board.
+You can choose any of the following programmers for the bluepill board.
 
 - J-Link
 - ST-Link
 
 :::info:
-The J-link programmers are more expensive than the ST-Link. The ST-Link can only be used for STMicro microcontroller.
-We recommend the ST-Link, because of its accessibility and price.
+The J-link programmers are more expensive than the ST-Link because they are compatible with many devices and offer extended functionality. The ST-Link is only for use with the STMicro microcontroller.
+We recommend the ST-Link, because it's easy to use and it's cheaper.
 :::
 
 ## Step 2. Wire the external programmer to your microcontroller
 
-To use your external programmer, you need to wire it to your bluepill
+To use your external programmer, you need to wire it to your bluepill board.
 
 ### J-Link
 
-1. Connect the following pins from the bluepill to the J-Link
+1. Connect the following pins from the bluepill board to the J-Link:
 
     |    **bluepill**    |    **J-Link (pin number)**   |
     |-------------|-------------------|
@@ -40,10 +40,9 @@ To use your external programmer, you need to wire it to your bluepill
 
 If the connections are correct, your PC should detect that the J-Link is connected.
 
-    
 ### ST-Link
 
-1. Connect the following pins from the bluepill to the J-Link
+1. Connect the following pins from the bluepill board to the J-Link:
 
     |    **bluepill**    |    **ST-Link**   |
     |-------------|-------------------|
@@ -54,4 +53,4 @@ If the connections are correct, your PC should detect that the J-Link is connect
     
 2. Plug the ST-Link into the USB port of your PC
     
-If the connections are correct, your PC should detect that the ST-Link is connected.
+If the wiring is correct, your PC should detect that the ST-Link is connected.


### PR DESCRIPTION
# Description of change

Adds Platform IO setup guides to `doc-index.md` to make sure they are displayed in the project's side nav.
Adds some small language improvements and signposting.

# Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

# Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my changes