### PR TITLE
Update advice for choosing an attachment interval

### DIFF
--- a/wallets/0.1/hub/how-to-guides/configure-hub.md
+++ b/wallets/0.1/hub/how-to-guides/configure-hub.md
@@ -88,9 +88,9 @@ For example, if you use security level 3 in the [--keySecLevel](../references/co
 
 When Hub sends a sweep to a node, it monitors it to check for confirmation. If the sweep takes longer than the attachment interval to become confirmed, Hub [promotes and reattaches](root://getting-started/0.1/transactions/reattach-rebroadcast-promote.md) its tail transaction.
 
-The attachment interval you choose should depend on the current rate of confirmed transactions per second (CTPS) on the Tangle. To check the current rate, see [tanglebeat.com](http://tanglebeat.com/).
+The attachment interval you choose should depend on how long it's currently taking for transactions to be confirmed. To check the current time range, see [tanglebeat.com](http://tanglebeat.com/).
 
-For example, if the current CTPS rate is between 3 and 4 minutes, you should wait at least 4 minutes before reattaching or promoting transactions in a sweep.
+For example, if the current time range is between 3 and 4 minutes, you should wait at least 4 minutes before reattaching or promoting transactions in a sweep.
 
 If the attachment interval is too frequent, you will create unnecessary bundles to promote and reattach the sweep.
 


### PR DESCRIPTION
# Description of change

The previous advice was incorrect as the CTPS has nothing to do with how you choose the `attachmentInterval`.

This PR fixes the advice to use the time it takes for a transaction to go from pending to confirmed.

Thanks to @Thoralf-M for flagging this on Discord.

# Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

# Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

-  [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my changes