### PR TITLE
Add more details about public messages and fix typo

### DIFF
--- a/channels/1.0/guides/designing-the-workflow.md
+++ b/channels/1.0/guides/designing-the-workflow.md
@@ -76,13 +76,19 @@ The way that messages are linked affects whether receivers (the author and subsc
 
 ### Publishing public payloads
 
-The most basic messaging workflow for publishing **public payloads** on a channel is where all messages are linked to the `Announce` message. In this workflow, subscribers only rely on the `Announce` message to be able to process the author's `SignedPacket` messages.
+The most basic messaging workflow for publishing **public payloads** on a channel is where all messages are linked to the `Announce` message. In this workflow, subscribers only rely on the `Announce` message to be able to process the author's `SignedPacket` or `TaggedPacket` messages.
 
 ![Annonce message linked to a SignedPacket message](../images/signedpacket-workflow.png)
 
-### Publishing masked payloads
+:::info:
+`SignedPacket` messages can be sent only by the author.
 
-In general, all masked payloads rely on a `Keyload` message. This message contains an encrypted session key that allows authorized subscribers to do the following:
+When `SignedPacket` or `TaggedPacket` messages are attached to an `Announce` message, any masked payloads in them can be read by everyone.
+:::
+
+### Publishing masked payloads that are encrypted
+
+For masked payloads to be encrypted, they must be linked to a `Keyload` message. This message contains the encrypted session key that allows authorized subscribers to do the following:
 
 - Decrypt the author's masked payloads in future messages that are linked to the `Keyload` message
 - Encrypt their own masked payloads in `TaggedPacket` messages

--- a/channels/1.0/tutorials/build-a-messaging-app.md
+++ b/channels/1.0/tutorials/build-a-messaging-app.md
@@ -247,7 +247,7 @@ In this step, you create the main function that calls the ones you just created.
 
     The subscriber needs all this information to get the messages from the channel.
 
-## Step 4. Set up the subscriber
+## Step 5. Set up the subscriber
 
 In this step, you write a function to read the author's messages from the Tangle and verify them. 
 


### PR DESCRIPTION
# Description of change

Added some more detail about the difference between linking messages to `Announce` messages and `Keyload` messages.

Fixed repeated `## Step 4.` header.

# Type of change

Choose a type of change, and delete any options that are not relevant.

- Enhancement (a non-breaking change which adds new content)

# Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my changes