### PR TITLE
Add missing guide to side nav

### DIFF
--- a/channels/1.1/doc-index.md
+++ b/channels/1.1/doc-index.md
@@ -4,6 +4,7 @@
 
 [Introduction/How Channels works](/how-it-works.md)
 
+[Guides/Designing the messaging workflow](/guides/designing-the-workflow.md)
 [Guides/Creating a new channel](/guides/creating-a-new-channel.md)
 [Guides/Creating a subscriber](/guides/creating-a-subscriber.md)
 [Guides/Sending links](/guides/sending-links.md)


### PR DESCRIPTION
# Description of change

Added the Designing a messaging workflow guide to the side nav so that other guides can link to it without getting a 404 error.

# Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

# Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my changes