### PR TITLE
Fix API doc and links

### DIFF
--- a/api-reference/home.md
+++ b/api-reference/home.md
@@ -3,11 +3,11 @@
 [Overview](/1.0/overview.md)
 ## See an overview of the available node APIs
 
-[IRI](/1.0/iri-api-reference.md)
+[IRI](root://iri/1.0/references/iri-api-reference.md)
 ## Use the IRI API to attach transactions to the Tangle, find the balance of addresses, and find transactions.
 
-[Chronicle](/1.0/chronicle-api-reference.md)
+[Chronicle](root://chronicle/1.0/references/chronicle-api-reference.md)
 ## Use the Chronicle API to find historical transactions.
 
-[GoShimmer](/1.0/goshimmer-api-reference.md)
+[GoShimmer](root://goshimmer/1.0/references/goshimmer-api-reference.md)
 ## Use the GoShimmer API to interact with the prototype IOTA network that's being developed without a Coordinator.

--- a/iri/1.0/references/iri-api-reference.md
+++ b/iri/1.0/references/iri-api-reference.md
@@ -281,7 +281,13 @@ The last 243 trytes of the return value consist of the following fields:
 
 ## broadcastTransactions
 
-Sends transaction trytes to a node. 
+Sends transaction trytes to a node.
+
+:::info:
+In the Hornet node software, transactions in requests to this endpoint are also attached to the node's view of the Tangle.
+
+In the IRI node software, you must also call the `storeTransactions` endpoint to attach the transactions to the node's view of the Tangle.
+:::
 
  ### Parameters
 
@@ -1665,7 +1671,13 @@ curl http://localhost:14265 \
 
 ## storeTransactions
 
-Stores transactions in a node's local storage.
+Stores transactions in a node's view of the Tangle.
+
+:::info:
+In the Hornet node software, transactions in requests to this endpoint are also gossiped to the node's neighbors.
+
+In the IRI node software, you must also call the `broadcastTransactions` endpoint to gossip the transactions to neighbors.
+:::
 
 ### Parameters
 
@@ -1746,7 +1758,6 @@ curl http://localhost:14265 \
 ### 200
 ```json
 {
-"trytes": ["JJSLJFJD9HMHHMKAJNRODFHUN ..."],
 "duration": 982
 }
 ```
@@ -1769,7 +1780,7 @@ curl http://localhost:14265 \
 
 Checks if an address was ever withdrawn from, either in the current epoch or in any previous epochs.
 
-If an address has a pending transaction, it's also considered 'spent'.
+If a pending input transaction exists in the Tangle for an address, it's also considered spent.
 
 ### Parameters
 


### PR DESCRIPTION
# Description of change

Removed the returned `trytes` field from the `storeTransactions` endpoint
Added notes about the differences between IRI and Hornet: Hornet stores all transactions when you call the `broadcastTransactions` endpoint
Fixed links to the API references on the home page

# Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

# Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my changes