### PR TITLE
[FIX] JS Core Tutorial code snippets and references to devnet.thetangle.org

### DIFF
--- a/core/1.0/tutorials/js/change-message-in-bundle.md
+++ b/core/1.0/tutorials/js/change-message-in-bundle.md
@@ -59,7 +59,7 @@ In this tutorial, we connect to a node on the [Devnet](root://getting-started/1.
 4. Use the [`getBundle()`](https://github.com/iotaledger/iota.js/blob/next/api_reference.md#module_core.getBundle) method to get all transactions in the tail transaction's bundle
 
     ```js
-   IOTA.getBundle(tail).then(bundle => {
+   iota.getBundle(tail).then(bundle => {
 
     });
     ```
@@ -109,7 +109,7 @@ In this tutorial, we connect to a node on the [Devnet](root://getting-started/1.
 9. Send your copy to a node
 
     ```js
-   IOTA.sendTrytes(newTrytes.reverse(),3,9).then(transactions => {
+   iota.sendTrytes(newTrytes.reverse(),3,9).then(transactions => {
     // Print your new tail transaction hash to the console
     console.log(transactions[0].hash);
     })
@@ -119,7 +119,7 @@ In this tutorial, we connect to a node on the [Devnet](root://getting-started/1.
     You reverse the bundle array because the library expects bundles to be sent head first.
     :::
 
-Now, you can [search for your new tail transaction](https://devnet.thetangle.org/) in the Tangle and see that it's in a bundle with the same bundle hash as the original.
+Now, you can [search for your new tail transaction](https://utils.iota.org/) in the Tangle and see that it's in a bundle with the same bundle hash as the original.
 
 :::success:Congratulations :tada:
 You've just changed the message of a tail transaction in a bundle and reattached a copy of that bundle to the Tangle.

--- a/core/1.0/tutorials/js/check-balance.md
+++ b/core/1.0/tutorials/js/check-balance.md
@@ -48,7 +48,7 @@ In this tutorial, we connect to a node on the [Devnet](root://getting-started/1.
 4. Use the [`getBalances()`](https://github.com/iotaledger/iota.js/blob/next/api_reference.md#module_core.getBalances) method to ask the IOTA node for the current balance of the address
 
     ```js
-   IOTA.getBalances([address], 100)
+   iota.getBalances([address], 100)
       .then(({ balances }) => {
       console.log(balances)
       })

--- a/core/1.0/tutorials/js/check-transaction-confirmation.md
+++ b/core/1.0/tutorials/js/check-transaction-confirmation.md
@@ -28,7 +28,7 @@ In this tutorial, we connect to a node on the [Devnet](root://getting-started/1.
 
 ## Code walkthrough
 
-1. Go to [devnet.thetangle.org](https://devnet.thetangle.org/) and find a confirmed transaction
+1. Go to [utils.iota.org](https://utils.iota.org/) and find a confirmed transaction
 
     :::info:Can't find a confirmed transaction?
     Click a transaction hash in the Latest milestones box, then click the branch transaction hash. This transaction is referenced and approved by the milestone, so it is in a confirmed state.
@@ -37,7 +37,7 @@ In this tutorial, we connect to a node on the [Devnet](root://getting-started/1.
 2. Pass the transaction hash to the [`getLatestInclusion()`](https://github.com/iotaledger/iota.js/blob/next/api_reference.md#module_core.getLatestInclusion) method to check if the IOTA node's latest solid subtangle milestone approves it
 
     ```js
-   IOTA.getLatestInclusion(['TRANSACTION HASH'])
+   iota.getLatestInclusion(['TRANSACTION HASH'])
     .then(states => console.log(states));
     ```
 
@@ -47,7 +47,7 @@ In this tutorial, we connect to a node on the [Devnet](root://getting-started/1.
     You could also use the `getInclusionStates()` method to check if a transaction is approved by an array of your own chosen transactions.
     :::
 
-5. Go to [devnet.thetangle.org](https://devnet.thetangle.org) and find a pending transaction
+5. Go to [utils.iota.org](https://utils.iota.org) and find a pending transaction
 
     :::info:Can't find a pending transaction?
     Click a transaction hash in the Latest transactions box. This transaction is a tip, so it is in a pending state.
@@ -56,7 +56,7 @@ In this tutorial, we connect to a node on the [Devnet](root://getting-started/1.
 6. Pass the transaction hash to the `getLatestInclusion()` method to check if the IOTA node's latest solid subtangle milestone approves it
 
     ```js
-   IOTA.getLatestInclusion(['TRANSACTION HASH'])
+   iota.getLatestInclusion(['TRANSACTION HASH'])
     .then(states => console.log(states));
     ```
 

--- a/core/1.0/tutorials/js/confirm-pending-bundle.md
+++ b/core/1.0/tutorials/js/confirm-pending-bundle.md
@@ -67,7 +67,7 @@ If the tail transaction isn't promotable, the [`replayBundle()`](https://github.
 
 ```js
 function autoPromoteReattach (tail) {
- IOTA.isPromotable(tail)
+ iota.isPromotable(tail)
     .then(promote => promote
     ? iota.promoteTransaction(tail, 3, 14)
         .then(()=> {
@@ -104,7 +104,7 @@ If a tail transaction has been confirmed, it's logged to the console along with 
 ```js
 function autoConfirm(tails){
 console.log(tails);
-   IOTA.getLatestInclusion(tails)
+   iota.getLatestInclusion(tails)
         .then(states => {
             // Check that none of the transactions have been confirmed
             if (states.indexOf(true) === -1) {
@@ -136,7 +136,7 @@ Click the green button to run the sample code in this tutorial and see the resul
 Before you run this sample code, find a pending tail transaction hash and store it in the `tails` array.
 
 :::info:Can't find a pending transaction?
-Go to [devnet.thetangle.org](https://devnet.thetangle.org) and click a transaction hash in the Latest transactions box. This transaction is a tip, so it is in a pending state.
+Go to [iota.utils.org](https://iota.utils..org) and click a transaction hash in the Latest transactions box. This transaction is a tip, so it is in a pending state.
 :::
 
 <iframe height="500px" width="100%" src="https://repl.it/@jake91/Confirm-pending-bundle?lite=true" scrolling="no" frameborder="no" allowtransparency="true" allowfullscreen="true" sandbox="allow-forms allow-pointer-lock allow-popups allow-same-origin allow-scripts allow-modals"></iframe>

--- a/core/1.0/tutorials/js/generate-an-address.md
+++ b/core/1.0/tutorials/js/generate-an-address.md
@@ -54,7 +54,7 @@ In this tutorial, we connect to a node on the [Devnet](root://getting-started/1.
 5. Use the [`getNewAddress()`](https://github.com/iotaledger/iota.js/blob/next/api_reference.md#module_core.getNewAddress) method to generate an unspent address
 
     ```js
-   IOTA.getNewAddress(seed, { index: 0, securityLevel: securityLevel, total: 1 })
+   iota.getNewAddress(seed, { index: 0, securityLevel: securityLevel, total: 1 })
         .then(address => {
             console.log('Your address is: ' + address);
         })

--- a/core/1.0/tutorials/js/listen-for-transactions.md
+++ b/core/1.0/tutorials/js/listen-for-transactions.md
@@ -42,7 +42,7 @@ In this tutorial, we connect to a node on the [Devnet](root://getting-started/1.
     ```js
     // Check for a command-line argument
     if (!process.argv[2]) {
-        // Prompt user to add an address to the commmand line
+        // Prompt user to add an address to the command line
         console.log('Listening for all transactions')
         console.log('---------------------')
         console.log('If you want to listen for transactions that are sent to a particular address,');
@@ -54,7 +54,7 @@ In this tutorial, we connect to a node on the [Devnet](root://getting-started/1.
     } else {
         console.log('Listening for transactions sent to this address: ' + process.argv[2])
         console.log(
-            'Remember to send a transaction to this address, and be patient: It can take 30seconds for the transaction to appear.')
+            'Remember to send a transaction to this address, and be patient: It can take 30 seconds for the transaction to appear.')
         // Subscribe to the address thats passed in via the CLI
         sock.subscribe(process.argv[2])
     }

--- a/core/1.0/tutorials/js/read-transactions.md
+++ b/core/1.0/tutorials/js/read-transactions.md
@@ -55,7 +55,7 @@ In this tutorial, we connect to a node on the [Devnet](root://getting-started/1.
 4. Use the [`getBundle()`](https://github.com/iotaledger/iota.js/blob/next/api_reference.md#module_core.getBundle) method to get all transactions in the tail transaction's bundle. Then, use the [`extractJSON()`](https://github.com/iotaledger/iota.js/tree/next/packages/extract-json) method to decode the JSON messages in the `signatureMessageFragment` fields of the bundle's transactions and print them to the console
 
     ```js
-   IOTA.getBundle(tailTransactionHash)
+   iota.getBundle(tailTransactionHash)
     .then(bundle => {
         console.log(JSON.parse(Extract.extractJson(bundle)));
     })

--- a/core/1.0/tutorials/js/send-your-first-bundle.md
+++ b/core/1.0/tutorials/js/send-your-first-bundle.md
@@ -1,6 +1,6 @@
 # Send a "hello world" transaction in Node.js
 
-**In this tutorial, you send a "hello world" message in a zero-value transaction. These transactions are useful for storing messages on the Tanglewithout having to send any IOTA tokens.**
+**In this tutorial, you send a "hello world" message in a zero-value transaction. These transactions are useful for storing messages on the Tangle without having to send any IOTA tokens.**
 
 ## Packages
 
@@ -100,7 +100,7 @@ In this tutorial, we connect to a node on the [Devnet](root://getting-started/1.
 8. To create a bundle from your `transfers` object, pass it to the [`prepareTransfers()`](https://github.com/iotaledger/iota.js/blob/next/api_reference.md#module_core.prepareTransfers) method. Then, pass the returned bundle trytes to the [`sendTrytes()`](https://github.com/iotaledger/iota.js/blob/next/api_reference.md#module_core.sendTrytes) method, which handles tip selection, remote proof of work, and sending the bundle to the node. For details about this process, see [Sending a transaction](root://getting-started/1.0/clients/sending-a-transaction.md).
 
     ```js
-   IOTA.prepareTransfers(seed, transfers)
+   iota.prepareTransfers(seed, transfers)
         .then(trytes => {
             return iota.sendTrytes(trytes, depth, minimumWeightMagnitude);
         })


### PR DESCRIPTION
# Description of change

In all the JS tutorial files I've substituted `IOTA.` by `iota.` in all code snippets. On the other hand I have replaced references to
the https://devnet.thetangle.org by https://utils.iota.org. 

I guess the latter is a change that would be needed to be done for all the files, so I will open an issue about it. 

# Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

# Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [X] I have performed a self-review of my changes