### PR TITLE
[Fix] Comnet document says Devnet when it should say Comnet. Link added

### DIFF
--- a/getting-started/1.0/networks/comnet.md
+++ b/getting-started/1.0/networks/comnet.md
@@ -1,6 +1,6 @@
 # The Comnet
 
-**The Devnet is similar to the Devnet, except it's maintained by the IOTA community. This topic lists some practical information for connecting to the Comnet.**
+**The Comnet is similar to the [Devnet](../networks/devnet.md), except it's maintained by the IOTA community. This topic lists some practical information for connecting to the Comnet.**
 
 ## Nodes
 
@@ -12,7 +12,7 @@ Use this URL for sending transactions and requesting information about the Tangl
 
 ## Minimum weight magnitude
 
-Transactions on the Comnet must use a minimum weight magnitude (MWM) of 10 to be valid.
+Transactions on the Comnet must use a minimum weight magnitude (MWM) of `10` to be valid.
 
 ## Consensus rules
 

--- a/getting-started/1.0/networks/comnet.md
+++ b/getting-started/1.0/networks/comnet.md
@@ -12,7 +12,7 @@ Use this URL for sending transactions and requesting information about the Tangl
 
 ## Minimum weight magnitude
 
-Transactions on the Comnet must use a minimum weight magnitude (MWM) of `10` to be valid.
+Transactions on the Comnet must use a minimum weight magnitude (MWM) of 10 to be valid.
 
 ## Consensus rules
 


### PR DESCRIPTION
# Description of change

Comnet document says Devnet when it should say Comnet. Link added

# Type of change

- Bug fix (a non-breaking change which fixes an issue)

# Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ x] I have performed a self-review of my changes