### PR TITLE
[FIX] 100 value parameter in check balance not needed and passing it leads to an error

### DIFF
--- a/client-libraries/0.1/how-to-guides/c/check-balance.md
+++ b/client-libraries/0.1/how-to-guides/c/check-balance.md
@@ -42,9 +42,6 @@ The network settings are defined in a `config.h` file, which we create in the [g
 3. Use the [`get_balances()`](https://github.com/iotaledger/entangled/blob/develop/cclient/api/core/get_balances.h) method to ask the IOTA node for the current balance of the address
 
     ```cpp
-    // Set the threshold (this is not used but we must set it)
-    balance_req->threshold = 100;
-
     if ((ret_code = iota_client_get_balances(service, balance_req, balance_res)) == RC_OK) {
         hash243_queue_entry_t *q_iter = NULL;
         size_t balance_cnt = get_balances_res_balances_num(balance_res);

--- a/compass/0.1/how-to-guides/set-up-a-private-tangle.md
+++ b/compass/0.1/how-to-guides/set-up-a-private-tangle.md
@@ -296,8 +296,7 @@ Call the [`getBalances`](root://iri/1.0/references/iri-api-reference.md#getbalan
      'command': 'getBalances',
      'addresses': [
      address
-     ],
-     'threshold':100
+     ]
      }
 
      var options = {

--- a/compass/1.0/tutorials/set-up-a-private-tangle.md
+++ b/compass/1.0/tutorials/set-up-a-private-tangle.md
@@ -292,8 +292,7 @@ Call the [`getBalances`](root://iri/1.0/references/iri-api-reference.md#getbalan
      'command': 'getBalances',
      'addresses': [
      address
-     ],
-     'threshold':100
+     ]
      }
 
      var options = {

--- a/compass/1.0/tutorials/set-up-one-command.md
+++ b/compass/1.0/tutorials/set-up-one-command.md
@@ -70,8 +70,7 @@ Using the [core JavaScript client library](root://core/1.0/overview.md) with Nod
      'command': 'getBalances',
      'addresses': [
      address
-     ],
-     'threshold':100
+     ]
      }
 
      var options = {

--- a/core/1.0/tutorials/c/check-balance.md
+++ b/core/1.0/tutorials/c/check-balance.md
@@ -55,9 +55,6 @@ The network settings are defined in a `config.h` file. See [C quickstart](root:/
         goto done;
     }
 
-    // Set the threshold (this is not used but we must set it)
-    balance_req->threshold = 100;
-
     if ((ret_code = iota_client_get_balances(service, balance_req, balance_res)) == RC_OK) {
         hash243_queue_entry_t *q_iter = NULL;
         size_t balance_cnt = get_balances_res_balances_num(balance_res);

--- a/core/1.0/tutorials/js/check-balance.md
+++ b/core/1.0/tutorials/js/check-balance.md
@@ -48,7 +48,7 @@ In this tutorial, we connect to a node on the [Devnet](root://getting-started/1.
 4. Use the [`getBalances()`](https://github.com/iotaledger/iota.js/blob/next/api_reference.md#module_core.getBalances) method to ask the IOTA node for the current balance of the address
 
     ```js
-   iota.getBalances([address], 100)
+   iota.getBalances([address])
       .then(({ balances }) => {
       console.log(balances)
       })

--- a/utils/0.1/community/one-command-tangle/overview.md
+++ b/utils/0.1/community/one-command-tangle/overview.md
@@ -110,8 +110,7 @@ Using the [core JavaScript client library](root://core/1.0/overview.md) with Nod
      'command': 'getBalances',
      'addresses': [
      address
-     ],
-     'threshold':100
+     ]
      }
 
      var options = {


### PR DESCRIPTION
# Description of change

When checking balance a second parameter with the value `100` is sent. As per the current API signature is not needed and leads to an error. 

# Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

# Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my changes