### PR TITLE
changed AWS marketplace link

### DIFF
--- a/hornet/1.1/tutorials/install-hornet.md
+++ b/hornet/1.1/tutorials/install-hornet.md
@@ -25,4 +25,4 @@ Use the following table to select an installation method for your operating syst
 
 Hornet is available as a one-click setup on the Amazon Web Services (AWS) Marketplace.
 
-For installation instructions, see the [IOTA Hornet Node page](https://aws.amazon.com/marketplace/pp/B08CGPLSYZ) on the AWS Marketplace.
+For installation instructions, see the [IOTA Hornet Node page](https://aws.amazon.com/marketplace/pp/B08KYFLWB7) on the AWS Marketplace.


### PR DESCRIPTION
# Description of change

The HORNET installation page had a link to a [deprecated version on the AWS Marketplace](https://aws.amazon.com/marketplace/pp/B08CGPLSYZ.) The link has been changed to the latest version: https://aws.amazon.com/marketplace/pp/B08KYFLWB7 

# Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)

# Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my changes