### PR TITLE
changed IRI to HORNET

### DIFF
--- a/iota-access/1.0/tutorials/get-started.md
+++ b/iota-access/1.0/tutorials/get-started.md
@@ -24,12 +24,11 @@ The policy store consists of interface servers for managing policies on the Tang
 To run the policy store, you need the following:
 - [npm](https://www.npmjs.com/get-npm)
 - [Docker](https://docs.docker.com/engine/install/#server)
-- [A local IRI node](root://compass/1.0/tutorials/set-up-one-command.md)
+- [A HORNET node](root://hornet/1.1/overview.md)
 
 :::info:
-The IRI node software is no longer supported by the public IOTA networks. Therefore, you need to [install one in a private network](root://compass/1.0/tutorials/set-up-one-command.md).
-
-Future version of Access will allow you to connect to Hornet node software so that you can run it in a public IOTA network.
+Lower disc space usage for the HORNET node in a testing enviromnent is achievable using a private Tangle.  
+Follow this guide to install one [install one in a private network](root://compass/1.0/tutorials/set-up-one-command.md).
 :::
 
 ---


### PR DESCRIPTION
According to the IOTA Access github a HORNET node is in use for the access policy store:
https://github.com/iotaledger/access-policy-store

# Description of change

Please write a summary of your changes and why you made them. Be sure to reference any related issues by adding `fixes # (issue)`.

# Type of change

Choose a type of change, and delete any options that are not relevant.

- Bug fix (a non-breaking change which fixes an issue)
- Enhancement (a non-breaking change which adds new content)

# Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [ ] I have followed the contribution guidelines for this project
- [ ] I have performed a self-review of my changes