### PR TITLE
removed Community faucet

### DIFF
--- a/getting-started/1.1/networks/devnet.md
+++ b/getting-started/1.1/networks/devnet.md
@@ -25,7 +25,6 @@ Use this endpoint to poll the node for new transactions.
 Use the following [faucets](../references/glossary.md#faucet) to transfer up to 1 Ki of IOTA tokens to one of your addresses in the Devnet:
 
 - **[Official faucet](https://faucet.devnet.iota.org/):** Distributes tokens in batches of 1 Ki
-- **[Community faucet](https://faucet.einfachiota.de/):** Distributes tokens in batches of up to 1 Ki
 
 ## Minimum weight magnitude
 


### PR DESCRIPTION
Community faucet will not be maintained before chrysalis pt2

# Description of change

Community faucet will not be maintained before chrysalis pt2 by the einfachIOTA team. Removed the link to the communtiy faucet.

# Type of change
- Enhancement (a non-breaking change which adds new content)

# Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x] I have followed the contribution guidelines for this project
- [x] I have performed a self-review of my changes