### PR TITLE
change hornet document addNeighbor's neighbors' port from 14265 to 15600

### DIFF
--- a/hornet/1.1/references/api-reference.md
+++ b/hornet/1.1/references/api-reference.md
@@ -60,8 +60,8 @@ import json
 command = {
   "command": "addNeighbors",
   "uris": [
-    "tcp://8.8.8.8:14265",
-    "tcp://8.8.8.8:14265"
+    "tcp://8.8.8.8:15600",
+    "tcp://8.8.8.8:15600"
   ]
 }
 
@@ -87,8 +87,8 @@ var request = require('request');
 var command = {
   "command": "addNeighbors",
   "uris": [
-    "tcp://8.8.8.8:14265",
-    "tcp://8.8.8.8:14265"
+    "tcp://8.8.8.8:15600",
+    "tcp://8.8.8.8:15600"
   ]
 }
 
@@ -118,8 +118,8 @@ curl http://localhost:14265 \
 -d '{
   "command": "addNeighbors",
   "uris": [
-    "tcp://8.8.8.8:14265",
-    "tcp://8.8.8.8:14265"
+    "tcp://8.8.8.8:15600",
+    "tcp://8.8.8.8:15600"
   ]
 }'
 ```


### PR DESCRIPTION
# Description of change

I try these API and found out that the neighbor's port is not 14265 but 15600 .
So I fix the document to prevent others like me spend lots of time on debug.

# Bug fix (a non-breaking change which fixes an issue)

Change Hornet Document's addNeighbor example's neighbors' port from 14265 to 15600

# Change checklist

Add an `x` to the boxes that are relevant to your changes, and delete any items that are not.

- [x ] I have followed the contribution guidelines for this project
- [ x] I have performed a self-review of my changes